### PR TITLE
feat: make isSecure flag configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Add connection to config/queue.php:
                 'lazy'      => env('RABBITMQ_LAZY_CONNECTION', true),
                 'keepalive' => env('RABBITMQ_KEEPALIVE_CONNECTION', false),
                 'heartbeat' => env('RABBITMQ_HEARTBEAT_CONNECTION', 0),
+                'secure'    => env('RABBITMQ_SECURE', false),
             ],
 
             'options' => [

--- a/config/RabbitMQConnectionConfig.php
+++ b/config/RabbitMQConnectionConfig.php
@@ -13,6 +13,7 @@ return [
         'lazy' => env('RABBITMQ_LAZY_CONNECTION', true),
         'keepalive' => env('RABBITMQ_KEEPALIVE_CONNECTION', false),
         'heartbeat' => env('RABBITMQ_HEARTBEAT_CONNECTION', 0),
+        'secure' => env('RABBITMQ_SECURE', false),
     ],
 
     'options' => [

--- a/src/Connectors/RabbitMQConnector.php
+++ b/src/Connectors/RabbitMQConnector.php
@@ -33,11 +33,13 @@ readonly class RabbitMQConnector implements ConnectorInterface
         $amqpConnectionConfig->setIsSecure(config('queue.connections.rabbitmq.hosts.secure'));
 
         // set SSL Options
-        $amqpConnectionConfig->setSslCaCert(config('queue.connections.rabbitmq.options.ssl_options.cafile'));
-        $amqpConnectionConfig->setSslCert(config('queue.connections.rabbitmq.options.ssl_options.local_cert'));
-        $amqpConnectionConfig->setSslKey(config('queue.connections.rabbitmq.options.ssl_options.local_key'));
-        $amqpConnectionConfig->setSslVerify(config('queue.connections.rabbitmq.options.ssl_options.verify_peer'));
-        $amqpConnectionConfig->setSslPassPhrase(config('queue.connections.rabbitmq.options.ssl_options.passphrase'));
+        if ($amqpConnectionConfig->isSecure()) {
+            $amqpConnectionConfig->setSslCaCert(config('queue.connections.rabbitmq.options.ssl_options.cafile'));
+            $amqpConnectionConfig->setSslCert(config('queue.connections.rabbitmq.options.ssl_options.local_cert'));
+            $amqpConnectionConfig->setSslKey(config('queue.connections.rabbitmq.options.ssl_options.local_key'));
+            $amqpConnectionConfig->setSslVerify(config('queue.connections.rabbitmq.options.ssl_options.verify_peer'));
+            $amqpConnectionConfig->setSslPassPhrase(config('queue.connections.rabbitmq.options.ssl_options.passphrase'));
+        }
 
         // Create AMQP Connection
         $connection = AMQPConnectionFactory::create($amqpConnectionConfig);

--- a/src/Connectors/RabbitMQConnector.php
+++ b/src/Connectors/RabbitMQConnector.php
@@ -30,6 +30,7 @@ readonly class RabbitMQConnector implements ConnectorInterface
         $amqpConnectionConfig->setIsLazy(config('queue.connections.rabbitmq.hosts.lazy'));
         $amqpConnectionConfig->setKeepalive(config('queue.connections.rabbitmq.hosts.keepalive'));
         $amqpConnectionConfig->setHeartbeat(config('queue.connections.rabbitmq.hosts.heartbeat'));
+        $amqpConnectionConfig->setIsSecure(config('queue.connections.rabbitmq.hosts.secure'));
 
         // set SSL Options
         $amqpConnectionConfig->setSslCaCert(config('queue.connections.rabbitmq.options.ssl_options.cafile'));


### PR DESCRIPTION
These changes allow the RabbitMQ connection security configuration to be more flexible and environment-driven. The secure setting is now pulled from the config or environment variable, improving maintainability and adaptability for various environments.