### PR TITLE
fix: address open issue compatibility bugs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,13 +19,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.2', '8.3', '8.4' ]
-        laravel: [ '11.*', '12.*' ]
         include:
-          - laravel: '12.*'
-            testbench: '10.*'
-          - laravel: '11.*'
+          - php: '8.2'
+            laravel: '11.*'
             testbench: '9.*'
+          - php: '8.2'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.3'
+            laravel: '11.*'
+            testbench: '9.*'
+          - php: '8.3'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.3'
+            laravel: '13.*'
+            testbench: '11.*'
+          - php: '8.4'
+            laravel: '11.*'
+            testbench: '9.*'
+          - php: '8.4'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.4'
+            laravel: '13.*'
+            testbench: '11.*'
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/src/Connection/ConnectionFactory.php
+++ b/src/Connection/ConnectionFactory.php
@@ -14,7 +14,7 @@ class ConnectionFactory
 
     private int $maxRetries;
 
-    private int $retryDelay;
+    private int|float $retryDelay;
 
     public function __construct(array $config)
     {
@@ -46,7 +46,7 @@ class ConnectionFactory
                 $attempt++;
 
                 if ($attempt < $this->maxRetries) {
-                    usleep($this->retryDelay * 1000); // Convert to microseconds
+                    usleep($this->retryDelayInMicroseconds());
                     $this->retryDelay *= 2; // Exponential backoff
                 }
             }
@@ -92,6 +92,11 @@ class ConnectionFactory
         }
 
         return $config;
+    }
+
+    private function retryDelayInMicroseconds(): int
+    {
+        return max(0, (int) round($this->retryDelay * 1000));
     }
 
     /**

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -27,7 +27,15 @@ class Consumer extends Worker
 
     private AMQPChannel $amqpChannel;
 
-    private ?RabbitMQJob $currentJob = null;
+    /**
+     * The job currently being processed.
+     *
+     * Keep this public and untyped to remain compatible with Laravel 13's
+     * Worker::$currentJob property declaration.
+     *
+     * @var RabbitMQJob|null
+     */
+    public $currentJob = null;
 
     public function setContainer(Container $container): void
     {
@@ -173,11 +181,11 @@ class Consumer extends Worker
         return ! (($this->isDownForMaintenance)() && ! $options->force) && ! $this->paused;
     }
 
-    public function stop($status = 0, $options = []): int
+    public function stop($status = 0, $options = null, $reason = null)
     {
         // For ext-amqp, we don't need to explicitly cancel consumption
         // as we're using a polling approach rather than a callback approach
 
-        return parent::stop($status);
+        return parent::stop($status, $options, $reason);
     }
 }

--- a/src/RabbitQueue.php
+++ b/src/RabbitQueue.php
@@ -117,6 +117,54 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
     }
 
     /**
+     * Get the number of pending jobs.
+     *
+     * Laravel 13 added queue metrics to the queue contract. RabbitMQ's passive
+     * queue declaration returns the number of ready messages, which maps to
+     * Laravel's pending job count.
+     *
+     * @throws AMQPChannelException
+     */
+    public function pendingSize($queue = null): int
+    {
+        return $this->size($queue);
+    }
+
+    /**
+     * Get the number of delayed jobs.
+     *
+     * This driver implements delays through per-delay TTL queues. RabbitMQ does
+     * not provide a single aggregate delayed count for the target queue, so this
+     * returns 0 rather than reporting an inaccurate value.
+     */
+    public function delayedSize($queue = null): int
+    {
+        return 0;
+    }
+
+    /**
+     * Get the number of reserved jobs.
+     *
+     * Reserved jobs are represented as unacknowledged RabbitMQ deliveries and
+     * are not exposed by a passive queue declaration in this driver.
+     */
+    public function reservedSize($queue = null): int
+    {
+        return 0;
+    }
+
+    /**
+     * Get the creation timestamp of the oldest pending job.
+     *
+     * RabbitMQ does not expose the creation time of the oldest ready message
+     * without consuming it, so this metric is unavailable.
+     */
+    public function creationTimeOfOldestPendingJob($queue = null): ?int
+    {
+        return null;
+    }
+
+    /**
      * Push a new job onto the queue.
      *
      * @param  mixed  $job


### PR DESCRIPTION
## Summary
- fix #8 by allowing fractional retry delays and converting them to integer microseconds before calling `usleep()`
- fix #9 by implementing Laravel 13 queue metric contract methods in `RabbitQueue`
- restore Laravel 13 CI coverage only for compatible PHP versions (8.3 and 8.4), while keeping Laravel 11/12 coverage on PHP 8.2+

## Notes
- `pendingSize()` maps to the existing RabbitMQ passive queue size.
- `delayedSize()` and `reservedSize()` return `0` because this driver cannot safely aggregate TTL delay queues or unacknowledged deliveries through passive queue declarations.
- `creationTimeOfOldestPendingJob()` returns `null` because RabbitMQ does not expose this without consuming a message.

Closes #8.
Closes #9.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core queue/connection behavior to match Laravel 13 contracts and changes retry backoff timing, which could affect job processing and connection stability if misconfigured.
> 
> **Overview**
> **Improves framework compatibility and correctness for retries and metrics.**
> 
> `ConnectionFactory` now accepts fractional `retry_delay` values and converts them to integer microseconds via a helper before calling `usleep()`, keeping exponential backoff behavior.
> 
> `RabbitQueue` implements Laravel 13 queue metric contract methods: `pendingSize()` delegates to existing `size()`, while `delayedSize()`, `reservedSize()`, and `creationTimeOfOldestPendingJob()` return safe default values (0/`null`) where RabbitMQ can’t report accurate metrics.
> 
> CI test matrix is reworked to explicitly test Laravel `11/12/13` against compatible PHP versions and corresponding `orchestra/testbench` versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5279d51e1d70bcc1e15b8ab608eda7bb3a02baf9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->