### PR TITLE
Fix published RabbitMQ config usage

### DIFF
--- a/src/LaravelRabbitQueueServiceProvider.php
+++ b/src/LaravelRabbitQueueServiceProvider.php
@@ -15,8 +15,10 @@ final class LaravelRabbitQueueServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(
             __DIR__.'/../config/rabbitmq.php',
-            'queue.connections.rabbitmq'
+            'rabbitmq'
         );
+
+        $this->configureRabbitMqConnection();
 
         if ($this->app->runningInConsole()) {
             $this->app->singleton('rabbitmq.consumer', function ($app): Consumer {
@@ -57,5 +59,16 @@ final class LaravelRabbitQueueServiceProvider extends ServiceProvider
                 __DIR__.'/../config/rabbitmq.php' => config_path('rabbitmq.php'),
             ], 'config');
         }
+    }
+
+    private function configureRabbitMqConnection(): void
+    {
+        $rabbitmqConfig = $this->app['config']->get('rabbitmq', []);
+        $queueConnectionConfig = $this->app['config']->get('queue.connections.rabbitmq', []);
+
+        $this->app['config']->set(
+            'queue.connections.rabbitmq',
+            array_merge($rabbitmqConfig, $queueConnectionConfig)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Load the package defaults into the published `rabbitmq` config key instead of directly into `queue.connections.rabbitmq`
- Populate `queue.connections.rabbitmq` from the merged `rabbitmq` config
- Preserve explicit `queue.connections.rabbitmq` values when users still configure the connection in `config/queue.php`

Fixes #12.

## Testing
- Not run (GitHub-only change; no local checkout/runtime available in this session).