### PR TITLE
Add production RabbitMQ configuration, Horizon support, and reliability upgrades

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -33,7 +35,6 @@ jobs:
         run: composer update --prefer-dist --no-progress --with-all-dependencies
 
       - name: Run Pint and commit fixes
-        if: github.event_name == 'push'
         run: |
           composer format
 
@@ -48,6 +49,5 @@ jobs:
           git commit -m "Apply Pint formatting"
           git push
 
-      - name: Run Pint in test mode
-        if: github.event_name == 'pull_request'
+      - name: Verify Pint formatting
         run: composer format-test

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   COMPOSER_PROCESS_TIMEOUT: 0
@@ -17,7 +17,7 @@ env:
   COMPOSER_NO_AUDIT: 1
 
 jobs:
-  phplint:
+  pint:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,5 +32,22 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress --with-all-dependencies
 
+      - name: Run Pint and commit fixes
+        if: github.event_name == 'push'
+        run: |
+          composer format
+
+          if git diff --quiet; then
+            echo "No Pint changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Apply Pint formatting"
+          git push
+
       - name: Run Pint in test mode
+        if: github.event_name == 'pull_request'
         run: composer format-test

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,12 +1,15 @@
 name: Coding Standards
 
 on:
-    push:
-      branches:
-        - '*'
-    pull_request:
-      branches:
-        - '*'
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+permissions:
+  contents: read
 
 env:
   COMPOSER_PROCESS_TIMEOUT: 0
@@ -15,18 +18,19 @@ env:
 
 jobs:
   phplint:
-      permissions:
-          contents: write
-      runs-on: ubuntu-latest
-      steps:
-          - uses: actions/checkout@v3
-          - name: "laravel-pint"
-            uses: aglipanci/laravel-pint-action@latest
-            with:
-                configPath: './pint.json'
+    runs-on: ubuntu-latest
 
-          - name: Commit changes
-            uses: stefanzweifel/git-auto-commit-action@v4
-            with:
-                commit_message: PHP Linting (Pint)
-                skip_fetch: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress --with-all-dependencies
+
+      - name: Run Pint in test mode
+        run: composer format-test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,12 @@ jobs:
           composer require "orchestra/testbench:${{ matrix.testbench }}" --dev --no-update
           composer update --prefer-dist --no-progress --with-all-dependencies
 
+      - name: Run formatting check
+        run: composer format-test
+
+      - name: Run static analysis
+        run: composer analyse
+
       - name: Clear PHPUnit cache
         run: |
           rm -rf .phpunit.cache

--- a/README.md
+++ b/README.md
@@ -3,977 +3,460 @@
 [![Latest Stable Version](https://poser.pugx.org/iamfarhad/laravel-rabbitmq/v/stable?format=flat-square)](https://packagist.org/packages/iamfarhad/laravel-rabbitmq)
 [![Total Downloads](https://poser.pugx.org/iamfarhad/laravel-rabbitmq/downloads?format=flat-square)](https://packagist.org/packages/iamfarhad/laravel-rabbitmq)
 [![License](https://poser.pugx.org/iamfarhad/laravel-rabbitmq/license?format=flat-square)](https://packagist.org/packages/iamfarhad/laravel-rabbitmq)
-[![Tests](https://github.com/iamfarhad/LaravelRabbitMQ/actions/workflows/tests.yml/badge.svg)](https://github.com/iamfarhad/LaravelRabbitMQ/actions/workflows/test.yml)
+[![Tests](https://github.com/iamfarhad/LaravelRabbitMQ/actions/workflows/tests.yml/badge.svg)](https://github.com/iamfarhad/LaravelRabbitMQ/actions/workflows/tests.yml)
 
-A robust RabbitMQ queue driver for Laravel featuring native Laravel Queue API integration, **advanced connection pooling**, **channel management**, and **high-performance async processing** capabilities.
+A production-focused RabbitMQ queue driver for Laravel with native Laravel Queue integration, connection/channel pooling, configurable RabbitMQ topology, Horizon hooks, Octane-safe pool reset support, and an optional high-performance `basic_consume` worker mode.
 
-## ✨ Key Features
+## Features
 
-### Core Features
-- 🚀 **High-Performance Connection Pooling** - Reuse connections efficiently with configurable limits
-- 🔄 **Advanced Channel Management** - Optimal AMQP channel pooling and lifecycle management  
-- 🛡️ **Resilient Retry Strategy** - Exponential backoff with configurable retry attempts
-- 📊 **Real-time Pool Monitoring** - Built-in statistics and health monitoring
-- 🔧 **Production Ready** - Comprehensive error handling and graceful shutdowns
-- ⚡ **Laravel Native** - Seamless integration with Laravel Queue API
-- 🎯 **Zero Configuration** - Works out of the box with sensible defaults
-
-### Advanced Features
-- 🔀 **Advanced Routing** - Topic, fanout, and headers exchanges for complex routing patterns
-- 🎯 **Multi-Queue Support** - Configure and manage multiple queues with different settings
-- 📈 **Exponential Backoff** - Intelligent retry mechanism with jitter to prevent thundering herd
-- 💀 **Dead Letter Exchange** - Automatic handling of failed messages with DLX
-- 🔁 **RPC Support** - Synchronous request-response pattern for remote procedure calls
-- ✅ **Publisher Confirms** - Reliable message delivery with broker acknowledgments
-- 🔒 **Transaction Management** - Atomic operations with commit/rollback support
-- ⏰ **Delayed Messages** - Schedule messages for future delivery (TTL or plugin-based)
-- 🐌 **Lazy Queues** - Optimize memory usage for high-volume message queues
-- ⚖️ **Consumer Priorities** - Control message distribution with priority consumers
-- 🔧 **Advanced Queue Options** - Full control over queue arguments and behavior
-
-## Table of Contents
-
-- [Key Features](#-key-features)
-- [Requirements](#requirements)
-- [Quick Start](#quick-start)
-- [Installation](#installation)
-- [Configuration](#configuration)
-  - [Basic Configuration](#basic-configuration)
-  - [Connection Pooling](#connection-pooling)
-  - [Environment Variables](#environment-variables)
-- [Usage](#usage)
-  - [Basic Usage](#basic-usage)
-  - [Pool Monitoring](#pool-monitoring)
-- [Advanced Features](#advanced-features)
-- [Performance Tuning](#performance-tuning)
-- [Production Deployment](#production-deployment)
-- [Testing](#testing)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [License](#license)
+- Laravel Queue API compatible RabbitMQ driver.
+- Native `ext-amqp` implementation for high-performance AMQP operations.
+- Connection and channel pooling with health checks and retry backoff.
+- Backward-compatible single-host config and production multi-host config.
+- Connection timeout support: read, write, and connect timeout.
+- Configurable exchange, exchange type, and routing-key publishing for normal Laravel jobs.
+- Lazy queues, priority queues, quorum queues, delayed messages, dead-letter routing, and failed-message rerouting.
+- Publisher confirms, transactions, RPC helpers, exchange helpers, and queue management helpers.
+- Optional Laravel Horizon integration via `RABBITMQ_WORKER=horizon`.
+- Optional Laravel Octane pool reset via `RABBITMQ_OCTANE_RESET_ON_REQUEST=true`.
+- Optional `basic_consume` worker mode via `RABBITMQ_CONSUME_MODE=consume` or `--consume-mode=consume`.
+- Artisan admin commands for declaring exchanges, declaring queues, purging queues, deleting queues, and viewing pool stats.
 
 ## Requirements
 
-- PHP 8.2 or higher
-- Laravel 11.x or 12.x
-- RabbitMQ Server 3.8+
-- ext-amqp PHP extension
-- ext-pcntl PHP extension (for parallel processing)
-
-## Quick Start
-
-Get up and running in 5 minutes:
-
-```bash
-# 1. Install package
-composer require iamfarhad/laravel-rabbitmq
-
-# 2. Install AMQP extension (if not already installed)
-pecl install amqp
-
-# 3. Start RabbitMQ (Docker)
-docker run -d --name rabbitmq \
-  -p 5672:5672 -p 15672:15672 \
-  rabbitmq:3-management
-
-# 4. Configure .env
-echo "QUEUE_CONNECTION=rabbitmq" >> .env
-echo "RABBITMQ_HOST=localhost" >> .env
-echo "RABBITMQ_PORT=5672" >> .env
-echo "RABBITMQ_USER=guest" >> .env
-echo "RABBITMQ_PASSWORD=guest" >> .env
-
-# 5. Create a job
-php artisan make:job ProcessPodcast
-
-# 6. Dispatch the job
-php artisan tinker
->>> dispatch(new App\Jobs\ProcessPodcast());
-
-# 7. Start worker
-php artisan rabbitmq:consume --queue=default
-```
-
-That's it! Your jobs are now processing through RabbitMQ. 🎉
+- PHP 8.2 or higher.
+- Laravel 11.x, 12.x, or 13.x.
+- RabbitMQ 3.8 or higher.
+- `ext-amqp` PHP extension.
+- `ext-pcntl` is optional and only required when running `rabbitmq:consume --num-processes` with a value greater than `1`.
 
 ## Installation
 
-### Install via Composer
-
 ```bash
 composer require iamfarhad/laravel-rabbitmq
 ```
 
-### Install AMQP Extension
-
-The package requires the `ext-amqp` PHP extension. Install it based on your environment:
-
-#### macOS (Homebrew)
+Install the AMQP extension when it is not already available:
 
 ```bash
-brew install rabbitmq-c
 pecl install amqp
 ```
 
-#### Ubuntu/Debian
+For Debian/Ubuntu images, install the native dependency first:
 
 ```bash
-sudo apt-get install librabbitmq-dev libssh-dev
+sudo apt-get update
+sudo apt-get install -y librabbitmq-dev libssh-dev
 sudo pecl install amqp
 ```
 
-#### Docker
-
-Add to your Dockerfile:
-
-```dockerfile
-# Install dependencies
-RUN apt-get update && apt-get install -y \
-    librabbitmq-dev \
-    libssh-dev
-
-# Install AMQP extension
-RUN pecl install amqp && docker-php-ext-enable amqp
-```
-
-#### Verify Installation
+Publish the config:
 
 ```bash
-php -m | grep amqp
+php artisan vendor:publish \
+  --provider="iamfarhad\LaravelRabbitMQ\LaravelRabbitQueueServiceProvider" \
+  --tag="config"
 ```
 
-You should see `amqp` in the output.
-
-### Publish Configuration
-
-```bash
-php artisan vendor:publish --provider="iamfarhad\LaravelRabbitMQ\LaravelRabbitQueueServiceProvider" --tag="config"
-```
-
-### Lumen Installation
-
-Register the service provider in `bootstrap/app.php`:
-
-```php
-$app->register(iamfarhad\LaravelRabbitMQ\LaravelRabbitQueueServiceProvider::class);
-```
-
-## Configuration
-
-### Basic Configuration
-
-Add the RabbitMQ connection to `config/queue.php`:
-
-```php
-'connections' => [
-    'rabbitmq' => [
-        'driver' => 'rabbitmq',
-        'queue'  => env('RABBITMQ_QUEUE', 'default'),
-        
-        'hosts' => [
-            'host'      => env('RABBITMQ_HOST', '127.0.0.1'),
-            'port'      => env('RABBITMQ_PORT', 5672),
-            'user'      => env('RABBITMQ_USER', 'guest'),
-            'password'  => env('RABBITMQ_PASSWORD', 'guest'),
-            'vhost'     => env('RABBITMQ_VHOST', '/'),
-            'heartbeat' => env('RABBITMQ_HEARTBEAT_CONNECTION', 0),
-        ],
-        
-        // 🚀 Connection and Channel Pool Configuration
-        'pool' => [
-            // Connection Pool Settings
-            'max_connections' => env('RABBITMQ_MAX_CONNECTIONS', 10),
-            'min_connections' => env('RABBITMQ_MIN_CONNECTIONS', 2),
-            
-            // Channel Pool Settings  
-            'max_channels_per_connection' => env('RABBITMQ_MAX_CHANNELS_PER_CONNECTION', 100),
-            
-            // Retry Strategy
-            'max_retries' => env('RABBITMQ_MAX_RETRIES', 3),
-            'retry_delay' => env('RABBITMQ_RETRY_DELAY', 1000), // milliseconds
-            
-            // Health Check Settings
-            'health_check_enabled' => env('RABBITMQ_HEALTH_CHECK_ENABLED', true),
-            'health_check_interval' => env('RABBITMQ_HEALTH_CHECK_INTERVAL', 30), // seconds
-        ],
-        
-        'options' => [
-            'ssl_options' => [
-                'cafile'      => env('RABBITMQ_SSL_CAFILE'),
-                'local_cert'  => env('RABBITMQ_SSL_LOCALCERT'),
-                'local_key'   => env('RABBITMQ_SSL_LOCALKEY'),
-                'verify_peer' => env('RABBITMQ_SSL_VERIFY_PEER', true),
-                'passphrase'  => env('RABBITMQ_SSL_PASSPHRASE'),
-            ],
-            'queue' => [
-                'job' => \iamfarhad\LaravelRabbitMQ\Jobs\RabbitMQJob::class,
-                'qos' => [
-                    'prefetch_size'  => 0,
-                    'prefetch_count' => 10,
-                    'global'         => false
-                ]
-            ],
-        ],
-    ],
-]
-```
-
-### Connection Pooling
-
-The package features advanced connection and channel pooling for optimal performance:
-
-#### Connection Pool Benefits
-- **Resource Efficiency**: Reuse existing connections instead of creating new ones
-- **Performance**: Significantly faster job processing with reduced connection overhead
-- **Reliability**: Automatic health monitoring and dead connection cleanup
-- **Scalability**: Configurable limits to handle varying workloads
-
-#### Pool Configuration Options
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `max_connections` | 10 | Maximum number of connections in the pool |
-| `min_connections` | 2 | Minimum connections to maintain |
-| `max_channels_per_connection` | 100 | Maximum channels per connection |
-| `max_retries` | 3 | Connection retry attempts |
-| `retry_delay` | 1000ms | Initial retry delay (exponential backoff) |
-| `health_check_enabled` | true | Enable automatic health monitoring |
-| `health_check_interval` | 30s | Health check frequency |
-
-### Environment Variables
-
-Add to your `.env` file:
+Set Laravel to use RabbitMQ:
 
 ```env
-# Basic RabbitMQ Configuration
 QUEUE_CONNECTION=rabbitmq
+```
 
-# RabbitMQ Connection
+## Quick start
+
+```env
+QUEUE_CONNECTION=rabbitmq
 RABBITMQ_HOST=127.0.0.1
 RABBITMQ_PORT=5672
 RABBITMQ_USER=guest
 RABBITMQ_PASSWORD=guest
 RABBITMQ_VHOST=/
 RABBITMQ_QUEUE=default
-
-# Connection Options
-RABBITMQ_HEARTBEAT_CONNECTION=0
-
-# 🚀 Connection Pool Configuration
-RABBITMQ_MAX_CONNECTIONS=10
-RABBITMQ_MIN_CONNECTIONS=2
-RABBITMQ_MAX_CHANNELS_PER_CONNECTION=100
-
-# 🛡️ Retry Strategy
-RABBITMQ_MAX_RETRIES=3
-RABBITMQ_RETRY_DELAY=1000
-
-# 📊 Health Monitoring
-RABBITMQ_HEALTH_CHECK_ENABLED=true
-RABBITMQ_HEALTH_CHECK_INTERVAL=30
-
-# SSL/TLS Configuration (Optional)
-RABBITMQ_SECURE=false
-#RABBITMQ_SSL_CAFILE=/path/to/ca.pem
-#RABBITMQ_SSL_LOCALCERT=/path/to/cert.pem
-#RABBITMQ_SSL_LOCALKEY=/path/to/key.pem
-#RABBITMQ_SSL_VERIFY_PEER=true
 ```
 
-## Usage
+Start RabbitMQ locally:
 
-### Basic Usage
+```bash
+docker run -d --name rabbitmq \
+  -p 5672:5672 \
+  -p 15672:15672 \
+  rabbitmq:3-management
+```
 
-#### Job Dispatching
+Dispatch Laravel jobs normally:
 
 ```php
-// Dispatch to default queue
-dispatch(new ProcessPodcast($podcast));
-
-// Dispatch to specific queue
-dispatch(new ProcessPodcast($podcast))->onQueue('podcasts');
-
-// Delayed dispatch
-dispatch(new ProcessPodcast($podcast))->delay(now()->addMinutes(10));
+dispatch(new App\Jobs\ProcessPodcast($podcast));
+dispatch(new App\Jobs\ProcessPodcast($podcast))->onQueue('podcasts');
+dispatch(new App\Jobs\ProcessPodcast($podcast))->delay(now()->addMinutes(10));
 ```
 
-### Creating Jobs
+Run a worker:
 
-```php
-<?php
-
-namespace App\Jobs;
-
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
-
-class ProcessPodcast implements ShouldQueue
-{
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
-    public function __construct(
-        public Podcast $podcast
-    ) {}
-
-    public function handle(): void
-    {
-        // Process the podcast...
-    }
-}
+```bash
+php artisan rabbitmq:consume --queue=default --num-processes=1
 ```
 
-### Running Workers
-
-#### Standard Laravel Worker
+Laravel's default worker also works:
 
 ```bash
 php artisan queue:work rabbitmq --queue=default
 ```
 
-#### Dedicated RabbitMQ Consumer (Recommended)
+## Configuration
 
-```bash
-php artisan rabbitmq:consume --queue=default
-```
+The package merges `config/rabbitmq.php` into `queue.connections.rabbitmq`, so you can configure the package from the published config file or directly in `config/queue.php`.
 
-### Consumer Command Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--queue` | Queue names to process (comma separated) | default |
-| `--once` | Process single job and exit | false |
-| `--stop-when-empty` | Stop when queue is empty | false |
-| `--delay` | Delay for failed jobs (seconds) | 0 |
-| `--memory` | Memory limit in MB | 128 |
-| `--timeout` | Job timeout in seconds | 60 |
-| `--tries` | Number of attempts | 1 |
-| `--sleep` | Sleep when no jobs available | 3 |
-| `--num-processes` | Number of parallel processes | 2 |
-| `--max-jobs` | Maximum jobs before restart | 0 |
-| `--max-time` | Maximum runtime in seconds | 0 |
-
-### Pool Monitoring
-
-Monitor your connection and channel pools in real-time:
-
-#### View Current Pool Statistics
-
-```bash
-# Show current pool stats
-php artisan rabbitmq:pool-stats
-
-# Output in JSON format
-php artisan rabbitmq:pool-stats --json
-
-# Watch stats in real-time (refreshes every 5 seconds)
-php artisan rabbitmq:pool-stats --watch --interval=5
-```
-
-#### Example Pool Stats Output
-
-```
-📡 Connection Pool
-├─ Max Connections: 10
-├─ Min Connections: 2
-├─ Current Connections: 3
-├─ Active Connections: 1
-└─ Available Connections: 2
-
-🔀 Channel Pool
-├─ Max Channels/Connection: 100
-├─ Current Channels: 5
-├─ Active Channels: 2
-└─ Available Channels: 3
-
-⚙️ Configuration
-├─ Max Retries: 3
-├─ Retry Delay: 1000ms
-├─ Health Check: Enabled
-└─ Health Check Interval: 30s
-
-📊 Utilization
-├─ Connection Utilization: 33.3%
-├─ Pool Capacity Used: 30.0%
-└─ Channel Utilization: 40.0%
-
-🟢 Pool Status: Healthy
-```
-
-#### Pool Health Indicators
-
-- 🟢 **Healthy**: All pools operating within normal parameters
-- 🟡 **Warning**: Pool utilization high or below minimum thresholds
-- 🔴 **Critical**: Pool exhausted or connection failures detected
-
-## Performance Tuning
-
-### Connection Pool Optimization
-
-#### High-Throughput Applications
-```env
-# Increase pool sizes for high-volume processing
-RABBITMQ_MAX_CONNECTIONS=20
-RABBITMQ_MIN_CONNECTIONS=5
-RABBITMQ_MAX_CHANNELS_PER_CONNECTION=200
-```
-
-#### Low-Latency Applications  
-```env
-# Reduce retry delays for faster failover
-RABBITMQ_MAX_RETRIES=2
-RABBITMQ_RETRY_DELAY=500
-RABBITMQ_HEALTH_CHECK_INTERVAL=15
-```
-
-#### Resource-Constrained Environments
-```env
-# Minimize resource usage
-RABBITMQ_MAX_CONNECTIONS=3
-RABBITMQ_MIN_CONNECTIONS=1
-RABBITMQ_MAX_CHANNELS_PER_CONNECTION=50
-RABBITMQ_HEALTH_CHECK_INTERVAL=60
-```
-
-### Performance Recommendations
-
-| Scenario | Max Connections | Min Connections | Channels/Connection |
-|----------|----------------|----------------|-------------------|
-| **Development** | 3 | 1 | 50 |
-| **Small Production** | 10 | 2 | 100 |
-| **High-Volume** | 20 | 5 | 200 |
-| **Enterprise** | 50 | 10 | 500 |
-
-### Monitoring Performance
-
-```bash
-# Monitor pool efficiency
-php artisan rabbitmq:pool-stats --watch
-
-# Check for bottlenecks
-php artisan queue:monitor rabbitmq:default,rabbitmq:high-priority
-
-# View failed jobs
-php artisan queue:failed
-```
-
-## Advanced Features
-
-### Priority Queues
-
-Enable priority-based processing:
+### Single-host configuration
 
 ```php
-// In config/queue.php
-'options' => [
-    'queue' => [
-        'arguments' => [
-            'x-max-priority' => 10
-        ]
-    ]
-]
-
-// Dispatch with priority
-dispatch(new UrgentJob($data))->onQueue('priority')->withPriority(8);
-```
-
-### Quality of Service (QoS)
-
-Configure message prefetching:
-
-```php
-'options' => [
-    'queue' => [
-        'qos' => [
-            'prefetch_size'  => 0,
-            'prefetch_count' => 10,
-            'global'         => false
-        ]
-    ]
+'rabbitmq' => [
+    'driver' => 'rabbitmq',
+    'queue' => env('RABBITMQ_QUEUE', 'default'),
+    'hosts' => [
+        'host' => env('RABBITMQ_HOST', '127.0.0.1'),
+        'port' => env('RABBITMQ_PORT', 5672),
+        'user' => env('RABBITMQ_USER', 'guest'),
+        'password' => env('RABBITMQ_PASSWORD', 'guest'),
+        'vhost' => env('RABBITMQ_VHOST', '/'),
+        'heartbeat' => env('RABBITMQ_HEARTBEAT_CONNECTION', 0),
+        'read_timeout' => env('RABBITMQ_READ_TIMEOUT', 0),
+        'write_timeout' => env('RABBITMQ_WRITE_TIMEOUT', 0),
+        'connect_timeout' => env('RABBITMQ_CONNECT_TIMEOUT', 0),
+    ],
 ]
 ```
 
-### SSL/TLS Support
+### Multi-host configuration
 
-Enable secure connections:
+Use a list of hosts for basic high-availability. The connector randomly selects a host for each new connection attempt.
 
 ```php
 'hosts' => [
-    'secure' => true,
-    // other host config...
-],
-
-'options' => [
-    'ssl_options' => [
-        'cafile'      => '/path/to/ca.pem',
-        'local_cert'  => '/path/to/cert.pem',
-        'local_key'   => '/path/to/key.pem',
-        'verify_peer' => true,
+    [
+        'host' => 'rabbitmq-1',
+        'port' => 5672,
+        'user' => 'laravel',
+        'password' => 'secret',
+        'vhost' => '/',
     ],
-]
-```
-
-### Failed Job Handling
-
-Configure retry behavior in your job:
-
-```php
-class ProcessPayment implements ShouldQueue
-{
-    public $tries = 3;
-    public $maxExceptions = 2;
-    public $backoff = [1, 5, 10];
-
-    public function retryUntil(): DateTime
-    {
-        return now()->addMinutes(15);
-    }
-
-    public function failed(Throwable $exception): void
-    {
-        // Handle failure
-    }
-}
-```
-
-### Queue Management
-
-```php
-use iamfarhad\LaravelRabbitMQ\Facades\RabbitMQ;
-
-// Check if queue exists
-if (RabbitMQ::queueExists('my-queue')) {
-    // Queue exists
-}
-
-// Declare a new queue
-RabbitMQ::declareQueue('my-queue', $durable = true);
-
-// Purge queue messages
-RabbitMQ::purgeQueue('my-queue');
-
-// Delete queue
-RabbitMQ::deleteQueue('my-queue');
-```
-
-## 🚀 Advanced Features
-
-### Exponential Backoff
-
-Automatic retry with exponential backoff for failed operations:
-
-```php
-// Configuration in config/queue.php
-'connections' => [
-    'rabbitmq' => [
-        'backoff' => [
-            'enabled' => true,
-            'base_delay' => 1000,      // 1 second
-            'max_delay' => 60000,      // 60 seconds
-            'multiplier' => 2.0,       // Double delay each retry
-            'jitter' => true,          // Add randomness to prevent thundering herd
-        ],
-    ],
-],
-
-// Usage in your code
-$queue = Queue::connection('rabbitmq');
-$backoff = $queue->getBackoff();
-
-$result = $backoff->execute(function () {
-    // Your code that might fail
-    return performRiskyOperation();
-}, maxAttempts: 5);
-```
-
-### Advanced Routing with Exchanges
-
-#### Topic Exchange
-
-Route messages based on routing key patterns:
-
-```php
-use iamfarhad\LaravelRabbitMQ\Support\ExchangeManager;
-
-$queue = Queue::connection('rabbitmq');
-$exchangeManager = $queue->getExchangeManager();
-
-// Setup topic exchange
-$exchangeManager->setupTopicExchange('notifications', [
-    'email-queue' => ['user.*.email', 'admin.*.email'],
-    'sms-queue' => ['user.*.sms'],
-    'push-queue' => ['*.*.push'],
-]);
-
-// Publish with routing key
-$queue->publishToExchange(
-    'notifications',
-    json_encode(['message' => 'Hello']),
-    'user.signup.email'
-);
-```
-
-#### Fanout Exchange
-
-Broadcast messages to all bound queues:
-
-```php
-// Setup fanout exchange
-$exchangeManager->setupFanoutExchange('broadcasts', [
-    'logger-queue',
-    'analytics-queue',
-    'backup-queue',
-]);
-
-// Publish to all queues
-$queue->publishToExchange(
-    'broadcasts',
-    json_encode(['event' => 'user_registered'])
-);
-```
-
-#### Headers Exchange
-
-Route based on message headers:
-
-```php
-// Setup headers exchange
-$exchangeManager->setupHeadersExchange('documents', [
-    'pdf-queue' => ['x-match' => 'all', 'format' => 'pdf', 'priority' => 'high'],
-    'image-queue' => ['x-match' => 'any', 'format' => 'jpg', 'format' => 'png'],
-]);
-
-// Publish with headers
-$queue->publishToExchange(
-    'documents',
-    json_encode(['content' => '...']),
-    '',
-    ['format' => 'pdf', 'priority' => 'high']
-);
-```
-
-### Multi-Queue Configuration
-
-Configure multiple queues with different settings:
-
-```php
-// In config/queue.php
-'connections' => [
-    'rabbitmq' => [
-        'queues' => [
-            'default' => [
-                'name' => 'default',
-                'durable' => true,
-                'lazy' => false,
-                'priority' => null,
-            ],
-            'high-priority' => [
-                'name' => 'high-priority',
-                'durable' => true,
-                'lazy' => false,
-                'priority' => 10,
-                'bindings' => [
-                    ['exchange' => 'tasks', 'routing_key' => 'urgent.*'],
-                ],
-            ],
-            'bulk-processing' => [
-                'name' => 'bulk-processing',
-                'durable' => true,
-                'lazy' => true,  // Lazy queue for large message volumes
-                'priority' => null,
-            ],
-        ],
+    [
+        'host' => 'rabbitmq-2',
+        'port' => 5672,
+        'user' => 'laravel',
+        'password' => 'secret',
+        'vhost' => '/',
     ],
 ],
 ```
 
-### Lazy Queues
+### Pool configuration
 
-Optimize memory usage for queues with many messages:
+```env
+RABBITMQ_MAX_CONNECTIONS=10
+RABBITMQ_MIN_CONNECTIONS=2
+RABBITMQ_MAX_CHANNELS_PER_CONNECTION=100
+RABBITMQ_MAX_RETRIES=3
+RABBITMQ_RETRY_DELAY=1000
+RABBITMQ_HEALTH_CHECK_ENABLED=true
+RABBITMQ_HEALTH_CHECK_INTERVAL=30
+```
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `max_connections` | `10` | Maximum open AMQP connections. |
+| `min_connections` | `2` | Minimum warm connections to keep available. |
+| `max_channels_per_connection` | `100` | Channel cap per AMQP connection. |
+| `max_retries` | `3` | Connection retry attempts. |
+| `retry_delay` | `1000` | Initial retry delay in milliseconds. |
+| `health_check_enabled` | `true` | Enable pool health checks. |
+| `health_check_interval` | `30` | Health check interval in seconds. |
+
+## Publishing topology
+
+By default the package preserves RabbitMQ's default exchange behavior and routes jobs directly to the queue name. For production routing, configure an exchange and routing-key pattern:
+
+```env
+RABBITMQ_EXCHANGE=jobs
+RABBITMQ_EXCHANGE_TYPE=topic
+RABBITMQ_EXCHANGE_ROUTING_KEY=jobs.%s
+```
+
+`%s` is replaced with the Laravel queue name. For example, queue `emails` publishes with routing key `jobs.emails`.
+
+Supported exchange types:
+
+- `direct`
+- `fanout`
+- `topic`
+- `headers`
+
+## Queue options
+
+### Lazy queues
+
+```env
+RABBITMQ_QUEUE_LAZY=true
+```
+
+Or per queue:
 
 ```php
-// Declare a lazy queue
-$queue->declareAdvancedQueue(
-    'large-queue',
-    durable: true,
-    autoDelete: false,
-    lazy: true  // Messages stored on disk until needed
-);
-
-// Or configure in config/queue.php
 'queues' => [
-    'large-queue' => [
-        'name' => 'large-queue',
+    'bulk' => [
+        'name' => 'bulk',
         'lazy' => true,
     ],
 ],
 ```
 
-### Consumer Priorities
+### Priority queues
 
-Set consumer priority to control message distribution:
+```env
+RABBITMQ_PRIORITIZE_DELAYED=true
+RABBITMQ_QUEUE_MAX_PRIORITY=10
+```
+
+Per queue:
 
 ```php
-// In config/queue.php
 'queues' => [
-    'high-priority' => [
-        'name' => 'high-priority',
-        'priority' => 10,  // Higher priority consumers get messages first
+    'critical' => [
+        'name' => 'critical',
+        'priority' => 10,
     ],
 ],
-
-// Start consumer with priority
-php artisan rabbitmq:consume --queue=high-priority
 ```
 
-### Dead Letter Exchange (DLX)
+### Quorum queues
 
-Automatically handle failed messages:
-
-```php
-// Configuration
-'connections' => [
-    'rabbitmq' => [
-        'dead_letter' => [
-            'enabled' => true,
-            'exchange' => 'dlx',
-            'exchange_type' => 'direct',
-            'queue_suffix' => '.dlq',
-            'ttl' => 86400000,  // 24 hours in milliseconds
-        ],
-    ],
-],
-
-// Setup DLX for a queue
-$queue->setupDeadLetterExchange('my-queue');
-
-// Or declare queue with DLX
-$queue->declareAdvancedQueue(
-    'my-queue',
-    durable: true,
-    autoDelete: false,
-    deadLetterConfig: [
-        'exchange' => 'dlx',
-        'routing_key' => 'my-queue.failed',
-        'ttl' => 60000,  // 60 seconds
-    ]
-);
+```env
+RABBITMQ_QUEUE_QUORUM=true
 ```
 
-### Delayed Messages
-
-Schedule messages for future delivery:
+Per queue:
 
 ```php
-// Using TTL-based delay (built-in)
-$queue->publishDelayed(
-    'notifications',
-    json_encode(['message' => 'Reminder']),
-    delay: 3600,  // 1 hour
-    headers: ['type' => 'reminder']
-);
-
-// Using RabbitMQ Delayed Message Plugin
-// First enable in config
-'connections' => [
-    'rabbitmq' => [
-        'delayed_message' => [
-            'enabled' => true,
-            'plugin_enabled' => true,  // Requires rabbitmq_delayed_message_exchange plugin
-            'exchange' => 'delayed',
-        ],
+'queues' => [
+    'orders' => [
+        'name' => 'orders',
+        'quorum' => true,
     ],
 ],
-
-// Then publish delayed messages
-$queue->publishDelayed('my-queue', $payload, 3600);
 ```
 
-### RPC (Remote Procedure Call)
+Priority queues and quorum queues are mutually exclusive in RabbitMQ. When quorum mode is enabled, the package does not set `x-max-priority`.
 
-Synchronous request-response pattern:
+### Failed-message rerouting
 
-```php
-// Enable RPC in config
-'connections' => [
-    'rabbitmq' => [
-        'rpc' => [
-            'enabled' => true,
-            'timeout' => 30,  // seconds
-        ],
-    ],
-],
-
-// Client: Make RPC call
-$queue = Queue::connection('rabbitmq');
-$response = $queue->rpcCall(
-    'rpc-queue',
-    json_encode(['action' => 'calculate', 'data' => [1, 2, 3]]),
-    ['priority' => 'high']
-);
-
-// Server: Handle RPC requests
-use iamfarhad\LaravelRabbitMQ\Support\RpcServer;
-
-$channel = $queue->getChannel();
-$server = new RpcServer($channel, 'rpc-queue');
-
-$server->listen(function ($message, $headers) {
-    $data = json_decode($message, true);
-    
-    // Process request
-    $result = processRequest($data);
-    
-    // Return response
-    return json_encode(['result' => $result]);
-});
+```env
+RABBITMQ_REROUTE_FAILED=true
+RABBITMQ_FAILED_EXCHANGE=failed.jobs
+RABBITMQ_FAILED_ROUTING_KEY=%s.failed
 ```
 
-### Publisher Confirms
+When enabled, declared queues receive dead-letter arguments pointing failed messages to the configured failed exchange and routing key.
 
-Ensure reliable message delivery:
+## Worker modes
 
-```php
-// Enable publisher confirms
-'connections' => [
-    'rabbitmq' => [
-        'publisher_confirms' => [
-            'enabled' => true,
-            'timeout' => 5,  // seconds
-        ],
-    ],
-],
+### Poll mode
 
-// Messages are automatically confirmed when published
-$queue->push(new ProcessOrder($order));
+`poll` is the default and uses `basic_get`. It is the safest mode and matches Laravel's worker lifecycle expectations.
 
-// Manual control
-$confirms = $queue->getPublisherConfirms();
-$confirms->enable();
-
-// Publish messages
-$queue->pushRaw($payload, 'orders');
-
-// Wait for confirmation
-if ($confirms->waitForConfirms()) {
-    // Message confirmed by broker
-} else {
-    // Message not confirmed - handle error
-}
+```bash
+php artisan rabbitmq:consume --queue=default --consume-mode=poll
 ```
 
-### Transaction Management
+### Consume mode
 
-Atomic operations with transactions:
+`consume` uses RabbitMQ's `basic_consume` push-style delivery. It avoids polling overhead and is better for hot queues, but it should be used with one queue per worker process.
+
+```bash
+php artisan rabbitmq:consume --queue=default --consume-mode=consume
+```
+
+Or configure it globally:
+
+```env
+RABBITMQ_CONSUME_MODE=consume
+```
+
+### Parallel workers
+
+```bash
+php artisan rabbitmq:consume --queue=default --num-processes=4
+```
+
+`ext-pcntl` is required only for `--num-processes` greater than `1`.
+
+## Laravel Horizon
+
+Install Horizon in your Laravel application, then enable the Horizon queue integration:
+
+```env
+RABBITMQ_WORKER=horizon
+```
+
+When Horizon is installed and `RABBITMQ_WORKER=horizon` is set, the package uses an optional Horizon-aware queue class and dispatches Horizon events for:
+
+- pending jobs
+- pushed jobs
+- reserved jobs
+- deleted jobs
+- failed jobs
+
+The package does not require Horizon. All Horizon references are guarded and inactive when Horizon is not installed.
+
+## Laravel Octane
+
+Long-running Octane workers can reuse AMQP pools across requests. That is usually best for performance. If your application needs a fresh pool after every Octane request, enable:
+
+```env
+RABBITMQ_OCTANE_RESET_ON_REQUEST=true
+```
+
+This hook is optional and only active when Laravel Octane is installed.
+
+## Admin commands
+
+```bash
+# Pool stats
+php artisan rabbitmq:pool-stats
+php artisan rabbitmq:pool-stats --json
+php artisan rabbitmq:pool-stats --watch --interval=5
+
+# Exchanges
+php artisan rabbitmq:exchange-declare jobs --type=topic
+
+# Queues
+php artisan rabbitmq:queue-declare orders --durable=1
+php artisan rabbitmq:queue-declare bulk --lazy=1
+php artisan rabbitmq:queue-declare quorum-orders --quorum=1
+php artisan rabbitmq:queue-declare critical --priority=10
+php artisan rabbitmq:queue-purge orders --force
+php artisan rabbitmq:queue-delete orders --force
+```
+
+## Advanced helpers
+
+### Publish to an exchange
 
 ```php
-// Enable transactions
-'connections' => [
-    'rabbitmq' => [
-        'transactions' => [
-            'enabled' => true,
-        ],
-    ],
-],
-
-// Use transactions
 $queue = Queue::connection('rabbitmq');
 
-$queue->transaction(function () use ($queue) {
-    // All operations in this block are atomic
-    $queue->push(new ProcessOrder($order1));
-    $queue->push(new ProcessOrder($order2));
-    $queue->push(new ProcessOrder($order3));
-    
-    // If any operation fails, all are rolled back
-});
-
-// Manual transaction control
-$txManager = $queue->getTransactionManager();
-
-$txManager->begin();
-try {
-    $queue->push(new ProcessOrder($order));
-    $txManager->commit();
-} catch (\Exception $e) {
-    $txManager->rollback();
-    throw $e;
-}
-```
-
-### Advanced Queue Declaration
-
-Declare queues with all available options:
-
-```php
-$queue->declareAdvancedQueue(
-    name: 'advanced-queue',
-    durable: true,
-    autoDelete: false,
-    lazy: true,
-    priority: 10,
-    deadLetterConfig: [
-        'exchange' => 'dlx',
-        'routing_key' => 'failed',
-        'ttl' => 60000,
-    ],
-    additionalArguments: [
-        'x-max-length' => 10000,
-        'x-overflow' => 'reject-publish',
-    ]
-);
-```
-
-### Complete Example: E-commerce Order Processing
-
-```php
-// Setup exchanges and queues
-$exchangeManager = $queue->getExchangeManager();
-
-// Create topic exchange for orders
-$exchangeManager->setupTopicExchange('orders', [
-    'order-processing' => ['order.created', 'order.updated'],
-    'order-notifications' => ['order.*'],
-    'order-analytics' => ['order.completed'],
-]);
-
-// Setup high-priority queue with DLX
-$queue->declareAdvancedQueue(
-    'order-processing',
-    durable: true,
-    lazy: false,
-    priority: 10,
-    deadLetterConfig: [
-        'exchange' => 'dlx',
-        'routing_key' => 'order-processing.failed',
-    ]
-);
-
-// Publish order with routing
 $queue->publishToExchange(
-    'orders',
-    json_encode(['order_id' => 123, 'amount' => 99.99]),
-    'order.created',
-    ['priority' => 8, 'customer_id' => 456]
+    'notifications',
+    json_encode(['message' => 'Welcome']),
+    'user.created.email',
+    ['source' => 'users']
 );
-
-// Process with exponential backoff
-$backoff = $queue->getBackoff();
-$backoff->execute(function () use ($order) {
-    processOrder($order);
-}, maxAttempts: 3);
 ```
 
-## Production Deployment
+### Delayed messages
 
-### Supervisor Configuration
+```php
+$queue->publishDelayed('emails', $payload, delay: 3600);
+```
+
+For the RabbitMQ delayed-message plugin:
+
+```env
+RABBITMQ_DELAYED_PLUGIN_ENABLED=true
+RABBITMQ_DELAYED_EXCHANGE=delayed
+```
+
+### Publisher confirms
+
+```env
+RABBITMQ_PUBLISHER_CONFIRMS_ENABLED=true
+RABBITMQ_PUBLISHER_CONFIRMS_TIMEOUT=5
+```
+
+### RPC
+
+```env
+RABBITMQ_RPC_ENABLED=true
+RABBITMQ_RPC_TIMEOUT=30
+```
+
+```php
+$response = Queue::connection('rabbitmq')->rpcCall(
+    'rpc-queue',
+    json_encode(['action' => 'calculate'])
+);
+```
+
+### Transactions
+
+```env
+RABBITMQ_TRANSACTIONS_ENABLED=true
+```
+
+```php
+Queue::connection('rabbitmq')->transaction(function ($queue) {
+    $queue->push(new App\Jobs\ProcessOrder(1));
+    $queue->push(new App\Jobs\ProcessOrder(2));
+});
+```
+
+## Environment variables
+
+```env
+QUEUE_CONNECTION=rabbitmq
+RABBITMQ_QUEUE=default
+RABBITMQ_HOST=127.0.0.1
+RABBITMQ_PORT=5672
+RABBITMQ_USER=guest
+RABBITMQ_PASSWORD=guest
+RABBITMQ_VHOST=/
+RABBITMQ_HEARTBEAT_CONNECTION=0
+RABBITMQ_READ_TIMEOUT=0
+RABBITMQ_WRITE_TIMEOUT=0
+RABBITMQ_CONNECT_TIMEOUT=0
+RABBITMQ_SECURE=false
+
+RABBITMQ_MAX_CONNECTIONS=10
+RABBITMQ_MIN_CONNECTIONS=2
+RABBITMQ_MAX_CHANNELS_PER_CONNECTION=100
+RABBITMQ_MAX_RETRIES=3
+RABBITMQ_RETRY_DELAY=1000
+RABBITMQ_HEALTH_CHECK_ENABLED=true
+RABBITMQ_HEALTH_CHECK_INTERVAL=30
+
+RABBITMQ_EXCHANGE=
+RABBITMQ_EXCHANGE_TYPE=direct
+RABBITMQ_EXCHANGE_ROUTING_KEY=%s
+RABBITMQ_PRIORITIZE_DELAYED=false
+RABBITMQ_QUEUE_MAX_PRIORITY=10
+RABBITMQ_QUEUE_LAZY=false
+RABBITMQ_QUEUE_QUORUM=false
+RABBITMQ_REROUTE_FAILED=false
+RABBITMQ_FAILED_EXCHANGE=
+RABBITMQ_FAILED_ROUTING_KEY=%s.failed
+
+RABBITMQ_WORKER=default
+RABBITMQ_CONSUME_MODE=poll
+RABBITMQ_OCTANE_RESET_ON_REQUEST=false
+
+RABBITMQ_PUBLISHER_CONFIRMS_ENABLED=false
+RABBITMQ_PUBLISHER_CONFIRMS_TIMEOUT=5
+RABBITMQ_RPC_ENABLED=false
+RABBITMQ_RPC_TIMEOUT=30
+RABBITMQ_TRANSACTIONS_ENABLED=false
+RABBITMQ_DELAYED_PLUGIN_ENABLED=false
+RABBITMQ_DELAYED_EXCHANGE=delayed
+```
+
+## Production deployment
+
+### Supervisor example
 
 ```ini
 [program:laravel-rabbitmq]
 process_name=%(program_name)s_%(process_num)02d
-command=php /path/to/artisan rabbitmq:consume --queue=default --memory=256
+command=php /var/www/html/artisan rabbitmq:consume --queue=default --consume-mode=consume --memory=256 --tries=3 --timeout=60 --num-processes=1
 autostart=true
 autorestart=true
 stopasgroup=true
@@ -981,366 +464,73 @@ killasgroup=true
 user=www-data
 numprocs=4
 redirect_stderr=true
-stdout_logfile=/path/to/logs/rabbitmq.log
+stdout_logfile=/var/log/supervisor/laravel-rabbitmq.log
 stopwaitsecs=3600
 ```
 
-### Docker Setup
+For `--consume-mode=consume`, prefer one queue per worker process. Scale with Supervisor `numprocs`, containers, or process managers rather than a comma-separated queue list.
 
-#### Complete Docker Compose Example
+### Docker notes
 
-```yaml
-version: '3.8'
-
-services:
-  app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    environment:
-      QUEUE_CONNECTION: rabbitmq
-      RABBITMQ_HOST: rabbitmq
-      RABBITMQ_PORT: 5672
-      RABBITMQ_USER: laravel
-      RABBITMQ_PASSWORD: secret
-      RABBITMQ_VHOST: /
-      RABBITMQ_MAX_CONNECTIONS: 10
-      RABBITMQ_MIN_CONNECTIONS: 2
-    depends_on:
-      - rabbitmq
-    volumes:
-      - ./:/var/www/html
-
-  # Queue worker service
-  queue:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    command: php artisan rabbitmq:consume --queue=default --num-processes=4
-    environment:
-      QUEUE_CONNECTION: rabbitmq
-      RABBITMQ_HOST: rabbitmq
-      RABBITMQ_PORT: 5672
-      RABBITMQ_USER: laravel
-      RABBITMQ_PASSWORD: secret
-    depends_on:
-      - rabbitmq
-      - app
-    volumes:
-      - ./:/var/www/html
-    restart: unless-stopped
-
-  rabbitmq:
-    image: rabbitmq:3-management-alpine
-    ports:
-      - "5672:5672"
-      - "15672:15672"
-    environment:
-      RABBITMQ_DEFAULT_USER: laravel
-      RABBITMQ_DEFAULT_PASS: secret
-      RABBITMQ_DEFAULT_VHOST: /
-    volumes:
-      - rabbitmq_data:/var/lib/rabbitmq
-    healthcheck:
-      test: rabbitmq-diagnostics -q ping
-      interval: 30s
-      timeout: 10s
-      retries: 5
-
-volumes:
-  rabbitmq_data:
-```
-
-#### Dockerfile with AMQP Extension
+Install AMQP in your PHP image:
 
 ```dockerfile
-FROM php:8.4-fpm
-
-# Install system dependencies
 RUN apt-get update && apt-get install -y \
-    git \
-    curl \
-    libpng-dev \
-    libonig-dev \
-    libxml2-dev \
-    zip \
-    unzip \
     librabbitmq-dev \
     libssh-dev \
-    supervisor \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Install PHP extensions
-RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath
-
-# Install AMQP extension
-RUN pecl install amqp && docker-php-ext-enable amqp
-
-# Install Redis extension (optional)
-RUN pecl install redis && docker-php-ext-enable redis
-
-# Install Composer
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
-
-# Set working directory
-WORKDIR /var/www/html
-
-# Copy application files
-COPY . .
-
-# Install dependencies
-RUN composer install --no-dev --optimize-autoloader
-
-# Set permissions
-RUN chown -R www-data:www-data /var/www/html
-
-USER www-data
-
-EXPOSE 9000
-
-CMD ["php-fpm"]
+    && pecl install amqp \
+    && docker-php-ext-enable amqp
 ```
 
-#### Supervisor Configuration for Docker
-
-Create `deployment/supervisor/conf.d/laravel-worker.conf`:
-
-```ini
-[program:laravel-worker]
-process_name=%(program_name)s_%(process_num)02d
-command=php /var/www/html/artisan rabbitmq:consume --queue=default --sleep=3 --tries=3 --max-time=3600
-autostart=true
-autorestart=true
-stopasgroup=true
-killasgroup=true
-user=www-data
-numprocs=4
-redirect_stderr=true
-stdout_logfile=/var/www/html/storage/logs/worker.log
-stopwaitsecs=3600
-```
-
-Then update your Dockerfile to include supervisor:
+Install `pcntl` only if you use multi-process consumers inside the same PHP process:
 
 ```dockerfile
-# Copy supervisor configuration
-COPY deployment/supervisor/conf.d/*.conf /etc/supervisor/conf.d/
-
-# Start supervisor
-CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
+RUN docker-php-ext-install pcntl
 ```
 
-## Testing
-
-### Running Tests
+## Testing and quality
 
 ```bash
-# Run all tests
-composer test
-
-# Run specific test suites
-composer test:unit
-composer test:feature
-
-# Code formatting
-composer format
 composer format-test
+composer analyse
+composer test
 ```
 
-### Test Environment
-
-Set up RabbitMQ for testing:
-
-```bash
-docker run -d --name rabbitmq-test \
-  -p 5672:5672 -p 15672:15672 \
-  rabbitmq:3-management
-```
+The GitHub Actions test workflow runs Pint, PHPStan, and PHPUnit across the supported Laravel/PHP matrix with a RabbitMQ service container.
 
 ## Troubleshooting
 
-### Common Issues
+### `Class AMQPConnection not found`
 
-#### AMQP Extension Not Found
-
-**Error**: `Class "AMQPConnection" not found`
-
-**Solution**: Install the AMQP PHP extension:
+Install and enable `ext-amqp`:
 
 ```bash
-# Check if extension is installed
+pecl install amqp
 php -m | grep amqp
-
-# If not installed, follow installation steps above
-# For Docker, rebuild containers:
-docker-compose down
-docker-compose build --no-cache app queue
-docker-compose up -d
 ```
 
-#### Jobs Not Processing / No Output
+### Parallel worker error about `pcntl`
 
-**Symptoms**: Queue size decreases but no logs or output appear
-
-**Possible Causes**:
-
-1. **AMQP extension missing** - Check logs for `Class "AMQPConnection" not found`
-   ```bash
-   # Check container logs
-   docker logs laravel_queue --tail 100
-   
-   # Check Laravel logs
-   tail -f storage/logs/laravel.log
-   ```
-
-2. **Worker running in Docker** - Output goes to container stdout
-   ```bash
-   # View real-time worker output
-   docker logs -f laravel_queue
-   
-   # Or exec into container
-   docker exec -it laravel_queue php artisan rabbitmq:consume --queue=default -vvv
-   ```
-
-3. **Supervisor buffering output** - Logs may be buffered
-   ```bash
-   # Check supervisor logs
-   tail -f storage/logs/supervisor/laravel-worker-default.log
-   ```
-
-4. **Silent failures** - Add verbose flag
-   ```bash
-   php artisan rabbitmq:consume --queue=default -vvv
-   ```
-
-#### Connection Refused
-
-Ensure RabbitMQ is running and accessible:
+Install `ext-pcntl`, or run a single process:
 
 ```bash
-# Check RabbitMQ status
-docker ps | grep rabbitmq
-
-# Test connection
-telnet localhost 5672
-
-# Check RabbitMQ logs
-docker logs laravel_rabbitmq
+php artisan rabbitmq:consume --queue=default --num-processes=1
 ```
 
-#### Permission Denied
+### Queue size or queue existence checks return zero after missing queue errors
 
-Verify user permissions in RabbitMQ:
+RabbitMQ closes a channel after a passive queue declaration miss. The package releases that cached channel and uses a fresh channel on the next operation.
 
-```bash
-# Access RabbitMQ management UI
-# http://localhost:15672
-# Default: guest/guest
+### Horizon events do not appear
 
-# Create user with permissions
-docker exec laravel_rabbitmq rabbitmqctl add_user laravel secret
-docker exec laravel_rabbitmq rabbitmqctl set_permissions -p / laravel ".*" ".*" ".*"
-```
-
-#### Memory Issues
-
-Adjust consumer memory limits:
-
-```bash
-php artisan rabbitmq:consume --memory=512
-```
-
-#### Worker Keeps Restarting
-
-**Symptoms**: Supervisor shows workers constantly exiting and restarting
-
-**Solution**: Check for:
-
-1. **Missing AMQP extension** - Most common cause
-2. **Connection issues** - Verify RabbitMQ is accessible
-3. **Configuration errors** - Check `config/queue.php`
-4. **Memory limits** - Increase `--memory` option
-
-```bash
-# View supervisor status
-docker exec laravel_queue supervisorctl status
-
-# Check specific worker logs
-docker exec laravel_queue tail -f /var/log/supervisor/laravel-worker-default.log
-```
-
-#### Pool Exhaustion
-
-**Error**: Unable to get connection from pool
-
-**Solution**: Increase pool size:
+Confirm Horizon is installed and set:
 
 ```env
-RABBITMQ_MAX_CONNECTIONS=20
-RABBITMQ_MIN_CONNECTIONS=5
+RABBITMQ_WORKER=horizon
 ```
 
-#### Slow Message Processing
-
-**Symptoms**: Messages pile up in queue
-
-**Solutions**:
-
-1. **Increase worker count**:
-   ```bash
-   php artisan rabbitmq:consume --num-processes=8
-   ```
-
-2. **Adjust prefetch count**:
-   ```php
-   'options' => [
-       'queue' => [
-           'qos' => [
-               'prefetch_count' => 20,
-           ]
-       ]
-   ]
-   ```
-
-3. **Monitor pool stats**:
-   ```bash
-   php artisan rabbitmq:pool-stats --watch
-   ```
-
-## Architecture
-
-### Components
-
-- **RabbitQueue**: Core queue implementation
-- **Consumer**: Message consumer with daemon support
-- **RabbitMQJob**: Job representation with RabbitMQ features
-- **RabbitMQConnector**: Connection management
-- **ConsumeCommand**: Artisan command for consumption
-
-### Contracts
-
-- **RabbitQueueInterface**: Extended queue contract
-
-## Contributing
-
-1. Fork the repository
-2. Create feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit changes (`git commit -m 'Add amazing feature'`)
-4. Push to branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-### Development Standards
-
-- Follow PSR-12 coding standards
-- Write tests for new features
-- Update documentation
-- Use conventional commits
-
-## Support
-
-- [Issues](https://github.com/iamfarhad/LaravelRabbitMQ/issues)
-- [Discussions](https://github.com/iamfarhad/LaravelRabbitMQ/discussions)
+Then restart your workers.
 
 ## License
 
-This package is open-sourced software licensed under the [MIT license](LICENSE).
+The MIT License (MIT). See [LICENSE](LICENSE) for more information.

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
     "require": {
         "php": "^8.2",
         "ext-amqp": "*",
-        "ext-pcntl": "*",
         "illuminate/queue": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0"
     },
@@ -51,6 +50,9 @@
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-strict-rules": "^1.5",
         "laravel/pint": "^1.10"
+    },
+    "suggest": {
+        "ext-pcntl": "Required only when running rabbitmq:consume with --num-processes greater than 1."
     },
     "autoload": {
         "psr-4": {

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -7,6 +7,9 @@ return [
     'queue' => env('RABBITMQ_QUEUE', 'default'),
     'after_commit' => env('RABBITMQ_AFTER_COMMIT', false),
 
+    // Set to "horizon" to enable optional Horizon event integration when Laravel Horizon is installed.
+    'worker' => env('RABBITMQ_WORKER', 'default'),
+
     // Backward compatible single host config. You may also replace this with a list of hosts:
     // 'hosts' => [
     //     ['host' => 'rabbitmq-1', 'port' => 5672, 'user' => 'guest', 'password' => 'guest', 'vhost' => '/'],
@@ -47,6 +50,12 @@ return [
         'retry_delay' => env('RABBITMQ_RETRY_DELAY', 1000), // milliseconds
         'health_check_enabled' => env('RABBITMQ_HEALTH_CHECK_ENABLED', true),
         'health_check_interval' => env('RABBITMQ_HEALTH_CHECK_INTERVAL', 30), // seconds
+    ],
+
+    // Octane Integration
+    'octane' => [
+        // Keep false by default for performance. Enable when each request should start with fresh AMQP pools.
+        'reset_on_request' => env('RABBITMQ_OCTANE_RESET_ON_REQUEST', false),
     ],
 
     // Exponential Backoff Configuration
@@ -136,6 +145,8 @@ return [
         ],
         'queue' => [
             'job' => RabbitMQJob::class,
+            // rabbitmq:consume supports "poll" (basic_get) and "consume" (basic_consume) modes.
+            'consume_mode' => env('RABBITMQ_CONSUME_MODE', 'poll'),
             'qos' => [
                 'prefetch_size' => 0,
                 'prefetch_count' => 10,

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -5,7 +5,13 @@ use iamfarhad\LaravelRabbitMQ\Jobs\RabbitMQJob;
 return [
     'driver' => 'rabbitmq',
     'queue' => env('RABBITMQ_QUEUE', 'default'),
+    'after_commit' => env('RABBITMQ_AFTER_COMMIT', false),
 
+    // Backward compatible single host config. You may also replace this with a list of hosts:
+    // 'hosts' => [
+    //     ['host' => 'rabbitmq-1', 'port' => 5672, 'user' => 'guest', 'password' => 'guest', 'vhost' => '/'],
+    //     ['host' => 'rabbitmq-2', 'port' => 5672, 'user' => 'guest', 'password' => 'guest', 'vhost' => '/'],
+    // ],
     'hosts' => [
         'host' => env('RABBITMQ_HOST', '127.0.0.1'),
         'port' => env('RABBITMQ_PORT', 5672),
@@ -15,23 +21,30 @@ return [
         'lazy' => env('RABBITMQ_LAZY_CONNECTION', true),
         'keepalive' => env('RABBITMQ_KEEPALIVE_CONNECTION', false),
         'heartbeat' => env('RABBITMQ_HEARTBEAT_CONNECTION', 0),
+        'read_timeout' => env('RABBITMQ_READ_TIMEOUT', 0),
+        'write_timeout' => env('RABBITMQ_WRITE_TIMEOUT', 0),
+        'connect_timeout' => env('RABBITMQ_CONNECT_TIMEOUT', 0),
         'secure' => env('RABBITMQ_SECURE', false),
     ],
 
+    // Publishing Configuration for normal Laravel queue jobs.
+    'exchange' => env('RABBITMQ_EXCHANGE', ''),
+    'exchange_type' => env('RABBITMQ_EXCHANGE_TYPE', 'direct'),
+    'exchange_routing_key' => env('RABBITMQ_EXCHANGE_ROUTING_KEY', '%s'),
+    'prioritize_delayed' => env('RABBITMQ_PRIORITIZE_DELAYED', false),
+    'queue_max_priority' => env('RABBITMQ_QUEUE_MAX_PRIORITY', 10),
+    'quorum' => env('RABBITMQ_QUEUE_QUORUM', false),
+    'reroute_failed' => env('RABBITMQ_REROUTE_FAILED', false),
+    'failed_exchange' => env('RABBITMQ_FAILED_EXCHANGE', ''),
+    'failed_routing_key' => env('RABBITMQ_FAILED_ROUTING_KEY', '%s.failed'),
+
     // Connection and Channel Pool Configuration
     'pool' => [
-        // Connection Pool Settings
         'max_connections' => env('RABBITMQ_MAX_CONNECTIONS', 10),
         'min_connections' => env('RABBITMQ_MIN_CONNECTIONS', 2),
-
-        // Channel Pool Settings
         'max_channels_per_connection' => env('RABBITMQ_MAX_CHANNELS_PER_CONNECTION', 100),
-
-        // Retry Strategy
         'max_retries' => env('RABBITMQ_MAX_RETRIES', 3),
         'retry_delay' => env('RABBITMQ_RETRY_DELAY', 1000), // milliseconds
-
-        // Health Check Settings
         'health_check_enabled' => env('RABBITMQ_HEALTH_CHECK_ENABLED', true),
         'health_check_interval' => env('RABBITMQ_HEALTH_CHECK_INTERVAL', 30), // seconds
     ],
@@ -54,13 +67,6 @@ return [
             'auto_delete' => env('RABBITMQ_EXCHANGE_AUTO_DELETE', false),
             'arguments' => [],
         ],
-        // Add custom exchanges here
-        // 'notifications' => [
-        //     'name' => 'notifications',
-        //     'type' => 'topic',
-        //     'durable' => true,
-        //     'auto_delete' => false,
-        // ],
     ],
 
     // Queue Configuration
@@ -72,6 +78,7 @@ return [
             'exclusive' => env('RABBITMQ_QUEUE_EXCLUSIVE', false),
             'lazy' => env('RABBITMQ_QUEUE_LAZY', false),
             'priority' => env('RABBITMQ_QUEUE_PRIORITY', null), // null or max priority (1-255)
+            'quorum' => env('RABBITMQ_QUEUE_QUORUM', false),
             'arguments' => [],
             'bindings' => [
                 [
@@ -80,12 +87,6 @@ return [
                 ],
             ],
         ],
-        // Add custom queues here
-        // 'high-priority' => [
-        //     'name' => 'high-priority',
-        //     'durable' => true,
-        //     'priority' => 10,
-        // ],
     ],
 
     // Dead Letter Exchange Configuration
@@ -101,7 +102,7 @@ return [
     'delayed_message' => [
         'enabled' => env('RABBITMQ_DELAYED_MESSAGE_ENABLED', false),
         'exchange' => env('RABBITMQ_DELAYED_EXCHANGE', 'delayed'),
-        'plugin_enabled' => env('RABBITMQ_DELAYED_PLUGIN_ENABLED', false), // rabbitmq_delayed_message_exchange plugin
+        'plugin_enabled' => env('RABBITMQ_DELAYED_PLUGIN_ENABLED', false),
     ],
 
     // RPC Configuration
@@ -123,6 +124,9 @@ return [
     ],
 
     'options' => [
+        'read_timeout' => env('RABBITMQ_READ_TIMEOUT', 0),
+        'write_timeout' => env('RABBITMQ_WRITE_TIMEOUT', 0),
+        'connect_timeout' => env('RABBITMQ_CONNECT_TIMEOUT', 0),
         'ssl_options' => [
             'cafile' => env('RABBITMQ_SSL_CAFILE', null),
             'local_cert' => env('RABBITMQ_SSL_LOCALCERT', null),

--- a/src/Connection/ConnectionFactory.php
+++ b/src/Connection/ConnectionFactory.php
@@ -31,6 +31,7 @@ class ConnectionFactory
     public function createConnection(): AMQPConnection
     {
         $connectionConfig = $this->buildConnectionConfig();
+        $retryDelay = $this->retryDelay;
 
         $attempt = 0;
         $lastException = null;
@@ -46,8 +47,8 @@ class ConnectionFactory
                 $attempt++;
 
                 if ($attempt < $this->maxRetries) {
-                    usleep($this->retryDelayInMicroseconds());
-                    $this->retryDelay *= 2; // Exponential backoff
+                    usleep($this->retryDelayInMicroseconds($retryDelay));
+                    $retryDelay *= 2; // Exponential backoff for this connection attempt only
                 }
             }
         }
@@ -94,9 +95,9 @@ class ConnectionFactory
         return $config;
     }
 
-    private function retryDelayInMicroseconds(): int
+    private function retryDelayInMicroseconds(int|float $retryDelay): int
     {
-        return max(0, (int) round($this->retryDelay * 1000));
+        return max(0, (int) round($retryDelay * 1000));
     }
 
     /**

--- a/src/Connection/ConnectionFactory.php
+++ b/src/Connection/ConnectionFactory.php
@@ -24,7 +24,7 @@ class ConnectionFactory
     }
 
     /**
-     * Create a new AMQP connection with retry strategy
+     * Create a new AMQP connection with retry strategy.
      *
      * @throws ConnectionException
      */
@@ -65,34 +65,67 @@ class ConnectionFactory
     }
 
     /**
-     * Build connection configuration array
+     * Build connection configuration array.
      */
     private function buildConnectionConfig(): array
     {
+        $hostConfig = $this->selectHostConfig();
+        $options = $this->config['options'] ?? [];
+
         $config = [
-            'host' => $this->config['hosts']['host'] ?? '127.0.0.1',
-            'port' => $this->config['hosts']['port'] ?? 5672,
-            'login' => $this->config['hosts']['user'] ?? 'guest',
-            'password' => $this->config['hosts']['password'] ?? 'guest',
-            'vhost' => $this->config['hosts']['vhost'] ?? '/',
+            'host' => $hostConfig['host'] ?? '127.0.0.1',
+            'port' => $hostConfig['port'] ?? 5672,
+            'login' => $hostConfig['user'] ?? 'guest',
+            'password' => $hostConfig['password'] ?? 'guest',
+            'vhost' => $hostConfig['vhost'] ?? '/',
         ];
 
-        // Add optional connection parameters (but be selective about which ones)
         $optionalParams = [
             'heartbeat' => 'heartbeat',
-            // Note: timeouts can cause connection issues with some AMQP configurations
-            // 'read_timeout' => 'read_timeout',
-            // 'write_timeout' => 'write_timeout',
-            // 'connect_timeout' => 'connect_timeout',
+            'read_timeout' => 'read_timeout',
+            'write_timeout' => 'write_timeout',
+            'connect_timeout' => 'connect_timeout',
         ];
 
         foreach ($optionalParams as $configKey => $amqpKey) {
-            if (isset($this->config['hosts'][$configKey]) && $this->config['hosts'][$configKey] > 0) {
-                $config[$amqpKey] = $this->config['hosts'][$configKey];
+            $value = $hostConfig[$configKey] ?? $options[$configKey] ?? null;
+            if (is_numeric($value) && (float) $value > 0) {
+                $config[$amqpKey] = is_float($value + 0) ? (float) $value : (int) $value;
             }
         }
 
         return $config;
+    }
+
+    /**
+     * Select a host from either the legacy associative host config or a list of hosts.
+     */
+    private function selectHostConfig(): array
+    {
+        $hosts = $this->config['hosts'] ?? [];
+
+        if ($hosts === []) {
+            return [];
+        }
+
+        if ($this->isListOfHosts($hosts)) {
+            $availableHosts = array_values(array_filter($hosts, 'is_array'));
+
+            if ($availableHosts === []) {
+                return [];
+            }
+
+            shuffle($availableHosts);
+
+            return $availableHosts[0];
+        }
+
+        return $hosts;
+    }
+
+    private function isListOfHosts(array $hosts): bool
+    {
+        return array_is_list($hosts) && isset($hosts[0]) && is_array($hosts[0]);
     }
 
     private function retryDelayInMicroseconds(int|float $retryDelay): int
@@ -101,7 +134,7 @@ class ConnectionFactory
     }
 
     /**
-     * Test if connection is alive
+     * Test if connection is alive.
      */
     public function isConnectionAlive(AMQPConnection $connection): bool
     {
@@ -113,7 +146,7 @@ class ConnectionFactory
     }
 
     /**
-     * Close connection safely
+     * Close connection safely.
      */
     public function closeConnection(AMQPConnection $connection): void
     {

--- a/src/Connectors/RabbitMQConnector.php
+++ b/src/Connectors/RabbitMQConnector.php
@@ -25,9 +25,7 @@ class RabbitMQConnector implements ConnectorInterface
 
     private static ?PoolManager $poolManager = null;
 
-    public function __construct(private Dispatcher $dispatcher)
-    {
-    }
+    public function __construct(private Dispatcher $dispatcher) {}
 
     /**
      * @throws ConnectionException

--- a/src/Connectors/RabbitMQConnector.php
+++ b/src/Connectors/RabbitMQConnector.php
@@ -98,7 +98,7 @@ class RabbitMQConnector implements ConnectorInterface
 
     private function registerHorizonListeners(RabbitQueue $queue): void
     {
-        if (! $queue instanceof HorizonRabbitQueue || ! class_exists(self::HORIZON_JOB_FAILED)) {
+        if (!$queue instanceof HorizonRabbitQueue || !class_exists(self::HORIZON_JOB_FAILED)) {
             return;
         }
 

--- a/src/Connectors/RabbitMQConnector.php
+++ b/src/Connectors/RabbitMQConnector.php
@@ -98,7 +98,7 @@ class RabbitMQConnector implements ConnectorInterface
 
     private function registerHorizonListeners(RabbitQueue $queue): void
     {
-        if (!$queue instanceof HorizonRabbitQueue || !class_exists(self::HORIZON_JOB_FAILED)) {
+        if (! $queue instanceof HorizonRabbitQueue || ! class_exists(self::HORIZON_JOB_FAILED)) {
             return;
         }
 

--- a/src/Connectors/RabbitMQConnector.php
+++ b/src/Connectors/RabbitMQConnector.php
@@ -6,10 +6,13 @@ namespace iamfarhad\LaravelRabbitMQ\Connectors;
 
 use iamfarhad\LaravelRabbitMQ\Connection\PoolManager;
 use iamfarhad\LaravelRabbitMQ\Exceptions\ConnectionException;
+use iamfarhad\LaravelRabbitMQ\Horizon\HorizonRabbitQueue;
+use iamfarhad\LaravelRabbitMQ\Horizon\Listeners\RabbitMQFailedEvent;
 use iamfarhad\LaravelRabbitMQ\RabbitQueue;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\Connectors\ConnectorInterface;
+use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\WorkerStopping;
 
 class RabbitMQConnector implements ConnectorInterface
@@ -23,53 +26,103 @@ class RabbitMQConnector implements ConnectorInterface
      */
     public function connect(array $config = []): Queue
     {
-        // Get the full RabbitMQ configuration
-        $rabbitConfig = config('queue.connections.rabbitmq', []);
+        $rabbitConfig = config('queue.connections.rabbitmq', $config);
 
-        // Initialize pool manager if not already done (singleton pattern)
         if (self::$poolManager === null) {
             self::$poolManager = new PoolManager($rabbitConfig);
         }
 
         $defaultQueue = $rabbitConfig['queue'] ?? 'default';
         $options = $rabbitConfig['options'] ?? [];
+        $dispatchAfterCommit = (bool) ($rabbitConfig['after_commit'] ?? false);
+        $connectionName = (string) ($rabbitConfig['name'] ?? 'rabbitmq');
 
-        // Create RabbitQueue with pool manager
-        $rabbitQueue = new RabbitQueue(
+        $rabbitQueue = $this->makeQueue(
             self::$poolManager,
             $defaultQueue,
             $options,
-            false, // dispatchAfterCommit
-            'rabbitmq' // connectionName
+            $dispatchAfterCommit,
+            $connectionName,
+            $rabbitConfig
         );
 
-        // Register cleanup listener
-        $this->dispatcher->listen(WorkerStopping::class, function () {
-            if (self::$poolManager) {
-                self::$poolManager->closeAll();
-                self::$poolManager = null;
-            }
-        });
+        $this->registerCleanupListeners();
+        $this->registerHorizonListeners($rabbitQueue);
 
         return $rabbitQueue;
     }
 
-    /**
-     * Get the pool manager instance (for testing or advanced use)
-     */
+    private function makeQueue(
+        PoolManager $poolManager,
+        string $defaultQueue,
+        array $options,
+        bool $dispatchAfterCommit,
+        string $connectionName,
+        array $config
+    ): RabbitQueue {
+        if ($this->shouldUseHorizonQueue($config)) {
+            return new HorizonRabbitQueue(
+                $poolManager,
+                $defaultQueue,
+                $options,
+                $dispatchAfterCommit,
+                $connectionName
+            );
+        }
+
+        return new RabbitQueue(
+            $poolManager,
+            $defaultQueue,
+            $options,
+            $dispatchAfterCommit,
+            $connectionName
+        );
+    }
+
+    private function shouldUseHorizonQueue(array $config): bool
+    {
+        $worker = strtolower((string) ($config['worker'] ?? $config['options']['queue']['worker'] ?? 'default'));
+
+        return $worker === 'horizon'
+            && class_exists(\Laravel\Horizon\JobPayload::class)
+            && class_exists(\Laravel\Horizon\Events\JobFailed::class);
+    }
+
+    private function registerHorizonListeners(RabbitQueue $queue): void
+    {
+        if (! $queue instanceof HorizonRabbitQueue || ! class_exists(\Laravel\Horizon\Events\JobFailed::class)) {
+            return;
+        }
+
+        $this->dispatcher->listen(JobFailed::class, RabbitMQFailedEvent::class);
+    }
+
+    private function registerCleanupListeners(): void
+    {
+        $this->dispatcher->listen(WorkerStopping::class, fn () => self::resetPoolManager());
+
+        if ($this->shouldResetPoolAfterOctaneRequest()) {
+            $this->dispatcher->listen(\Laravel\Octane\Events\RequestTerminated::class, fn () => self::resetPoolManager());
+        }
+    }
+
+    private function shouldResetPoolAfterOctaneRequest(): bool
+    {
+        return class_exists(\Laravel\Octane\Events\RequestTerminated::class)
+            && (bool) config('queue.connections.rabbitmq.octane.reset_on_request', false);
+    }
+
     public static function getPoolManager(): ?PoolManager
     {
         return self::$poolManager;
     }
 
-    /**
-     * Reset the pool manager (for testing)
-     */
     public static function resetPoolManager(): void
     {
         if (self::$poolManager) {
             self::$poolManager->closeAll();
         }
+
         self::$poolManager = null;
     }
 }

--- a/src/Connectors/RabbitMQConnector.php
+++ b/src/Connectors/RabbitMQConnector.php
@@ -17,9 +17,17 @@ use Illuminate\Queue\Events\WorkerStopping;
 
 class RabbitMQConnector implements ConnectorInterface
 {
+    private const HORIZON_JOB_PAYLOAD = 'Laravel\\Horizon\\JobPayload';
+
+    private const HORIZON_JOB_FAILED = 'Laravel\\Horizon\\Events\\JobFailed';
+
+    private const OCTANE_REQUEST_TERMINATED = 'Laravel\\Octane\\Events\\RequestTerminated';
+
     private static ?PoolManager $poolManager = null;
 
-    public function __construct(private Dispatcher $dispatcher) {}
+    public function __construct(private Dispatcher $dispatcher)
+    {
+    }
 
     /**
      * @throws ConnectionException
@@ -84,13 +92,13 @@ class RabbitMQConnector implements ConnectorInterface
         $worker = strtolower((string) ($config['worker'] ?? $config['options']['queue']['worker'] ?? 'default'));
 
         return $worker === 'horizon'
-            && class_exists(\Laravel\Horizon\JobPayload::class)
-            && class_exists(\Laravel\Horizon\Events\JobFailed::class);
+            && class_exists(self::HORIZON_JOB_PAYLOAD)
+            && class_exists(self::HORIZON_JOB_FAILED);
     }
 
     private function registerHorizonListeners(RabbitQueue $queue): void
     {
-        if (! $queue instanceof HorizonRabbitQueue || ! class_exists(\Laravel\Horizon\Events\JobFailed::class)) {
+        if (! $queue instanceof HorizonRabbitQueue || ! class_exists(self::HORIZON_JOB_FAILED)) {
             return;
         }
 
@@ -102,13 +110,13 @@ class RabbitMQConnector implements ConnectorInterface
         $this->dispatcher->listen(WorkerStopping::class, fn () => self::resetPoolManager());
 
         if ($this->shouldResetPoolAfterOctaneRequest()) {
-            $this->dispatcher->listen(\Laravel\Octane\Events\RequestTerminated::class, fn () => self::resetPoolManager());
+            $this->dispatcher->listen(self::OCTANE_REQUEST_TERMINATED, fn () => self::resetPoolManager());
         }
     }
 
     private function shouldResetPoolAfterOctaneRequest(): bool
     {
-        return class_exists(\Laravel\Octane\Events\RequestTerminated::class)
+        return class_exists(self::OCTANE_REQUEST_TERMINATED)
             && (bool) config('queue.connections.rabbitmq.octane.reset_on_request', false);
     }
 

--- a/src/Console/Commands/ExchangeDeclareCommand.php
+++ b/src/Console/Commands/ExchangeDeclareCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelRabbitMQ\Console\Commands;
+
+use AMQPExchange;
+use iamfarhad\LaravelRabbitMQ\RabbitQueue;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Queue;
+
+class ExchangeDeclareCommand extends Command
+{
+    protected $signature = 'rabbitmq:exchange-declare
+                            {name : Exchange name}
+                            {--type=direct : Exchange type: direct, fanout, topic, headers}
+                            {--durable=1 : Declare as durable}
+                            {--auto-delete=0 : Declare as auto-delete}';
+
+    protected $description = 'Declare a RabbitMQ exchange';
+
+    public function handle(): int
+    {
+        $connection = Queue::connection('rabbitmq');
+
+        if (! $connection instanceof RabbitQueue) {
+            $this->error('The rabbitmq queue connection is not configured.');
+
+            return self::FAILURE;
+        }
+
+        $exchange = new AMQPExchange($connection->getAmqpChannel());
+        $exchange->setName((string) $this->argument('name'));
+        $exchange->setType($this->resolveType((string) $this->option('type')));
+
+        $flags = $this->toBool($this->option('durable')) ? AMQP_DURABLE : AMQP_NOPARAM;
+        if ($this->toBool($this->option('auto-delete'))) {
+            $flags |= AMQP_AUTODELETE;
+        }
+
+        $exchange->setFlags($flags);
+        $exchange->declareExchange();
+
+        $this->info(sprintf('Exchange [%s] declared.', $this->argument('name')));
+
+        return self::SUCCESS;
+    }
+
+    private function resolveType(string $type): string
+    {
+        return match (strtolower($type)) {
+            'fanout' => AMQP_EX_TYPE_FANOUT,
+            'topic' => AMQP_EX_TYPE_TOPIC,
+            'headers' => AMQP_EX_TYPE_HEADERS,
+            default => AMQP_EX_TYPE_DIRECT,
+        };
+    }
+
+    private function toBool(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/src/Console/Commands/QueueDeclareCommand.php
+++ b/src/Console/Commands/QueueDeclareCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelRabbitMQ\Console\Commands;
+
+use iamfarhad\LaravelRabbitMQ\RabbitQueue;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Queue;
+
+class QueueDeclareCommand extends Command
+{
+    protected $signature = 'rabbitmq:queue-declare
+                            {name : Queue name}
+                            {--durable=1 : Declare as durable}
+                            {--auto-delete=0 : Declare as auto-delete}
+                            {--lazy=0 : Use lazy queue mode}
+                            {--priority= : Maximum priority 1-255}
+                            {--quorum=0 : Declare as quorum queue}';
+
+    protected $description = 'Declare a RabbitMQ queue';
+
+    public function handle(): int
+    {
+        $connection = Queue::connection('rabbitmq');
+
+        if (! $connection instanceof RabbitQueue) {
+            $this->error('The rabbitmq queue connection is not configured.');
+
+            return self::FAILURE;
+        }
+
+        $arguments = [];
+
+        if ($this->toBool($this->option('lazy'))) {
+            $arguments['x-queue-mode'] = 'lazy';
+        }
+
+        if ($this->toBool($this->option('quorum'))) {
+            $arguments['x-queue-type'] = 'quorum';
+        } elseif (is_numeric($this->option('priority')) && (int) $this->option('priority') > 0) {
+            $arguments['x-max-priority'] = min((int) $this->option('priority'), 255);
+        }
+
+        $connection->declareQueue(
+            (string) $this->argument('name'),
+            $this->toBool($this->option('durable')),
+            $this->toBool($this->option('auto-delete')),
+            $arguments
+        );
+
+        $this->info(sprintf('Queue [%s] declared.', $this->argument('name')));
+
+        return self::SUCCESS;
+    }
+
+    private function toBool(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/src/Console/Commands/QueueDeleteCommand.php
+++ b/src/Console/Commands/QueueDeleteCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelRabbitMQ\Console\Commands;
+
+use iamfarhad\LaravelRabbitMQ\RabbitQueue;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Queue;
+
+class QueueDeleteCommand extends Command
+{
+    protected $signature = 'rabbitmq:queue-delete {name : Queue name} {--force : Skip confirmation}';
+
+    protected $description = 'Delete a RabbitMQ queue';
+
+    public function handle(): int
+    {
+        $name = (string) $this->argument('name');
+
+        if (! $this->option('force') && ! $this->confirm("Delete queue [{$name}]?")) {
+            $this->info('Cancelled.');
+
+            return self::SUCCESS;
+        }
+
+        $connection = Queue::connection('rabbitmq');
+
+        if (! $connection instanceof RabbitQueue) {
+            $this->error('The rabbitmq queue connection is not configured.');
+
+            return self::FAILURE;
+        }
+
+        $connection->deleteQueue($name);
+        $this->info("Queue [{$name}] deleted.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/QueuePurgeCommand.php
+++ b/src/Console/Commands/QueuePurgeCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelRabbitMQ\Console\Commands;
+
+use iamfarhad\LaravelRabbitMQ\RabbitQueue;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Queue;
+
+class QueuePurgeCommand extends Command
+{
+    protected $signature = 'rabbitmq:queue-purge {name : Queue name} {--force : Skip confirmation}';
+
+    protected $description = 'Purge all ready messages from a RabbitMQ queue';
+
+    public function handle(): int
+    {
+        $name = (string) $this->argument('name');
+
+        if (! $this->option('force') && ! $this->confirm("Purge queue [{$name}]?")) {
+            $this->info('Cancelled.');
+
+            return self::SUCCESS;
+        }
+
+        $connection = Queue::connection('rabbitmq');
+
+        if (! $connection instanceof RabbitQueue) {
+            $this->error('The rabbitmq queue connection is not configured.');
+
+            return self::FAILURE;
+        }
+
+        $connection->purgeQueue($name);
+        $this->info("Queue [{$name}] purged.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -34,7 +34,7 @@ final class ConsumeCommand extends WorkCommand
                             {--tries=1 : Number of times to attempt a job before logging it failed}
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--max-priority=null : Maximum priority level to consume}
-                            {--consumer-tag}
+                            {--consumer-tag= : Custom RabbitMQ consumer tag}
                             {--num-processes=2 : Number of processes to run in parallel}
                            ';
 

--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -35,6 +35,7 @@ final class ConsumeCommand extends WorkCommand
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--max-priority=null : Maximum priority level to consume}
                             {--consumer-tag= : Custom RabbitMQ consumer tag}
+                            {--consume-mode=poll : Consumer mode: poll or consume}
                             {--num-processes=2 : Number of processes to run in parallel}
                            ';
 
@@ -58,12 +59,10 @@ final class ConsumeCommand extends WorkCommand
             return 1;
         }
 
-        // Skip forking if only one process is needed
         if ($numProcesses === 1) {
             return $this->consume();
         }
 
-        // Check if pcntl extension is available
         if (! extension_loaded('pcntl')) {
             $this->error('The pcntl extension is required for parallel processing');
 
@@ -82,15 +81,13 @@ final class ConsumeCommand extends WorkCommand
             }
 
             if ($pid === 0) {
-                // Child process
                 exit($this->consume());
             }
-            // Parent process
+
             $childPids[] = $pid;
             $this->info("Started worker process $pid");
         }
 
-        // Set up signal handling for graceful termination
         if (function_exists('pcntl_signal')) {
             pcntl_signal(SIGTERM, function () use (&$childPids) {
                 foreach ($childPids as $pid) {
@@ -101,7 +98,6 @@ final class ConsumeCommand extends WorkCommand
             });
         }
 
-        // Wait for all child processes to finish
         foreach ($childPids as $pid) {
             pcntl_waitpid($pid, $status);
 
@@ -133,8 +129,8 @@ final class ConsumeCommand extends WorkCommand
             $consumer->setContainer($this->laravel);
             $consumer->setName((string) $this->option('name'));
             $consumer->setConsumerTag($this->generateConsumerTag());
+            $consumer->setConsumeMode((string) $this->option('consume-mode'));
 
-            // Only set max priority if it's provided and not null
             $maxPriority = $this->option('max-priority');
             if ($maxPriority !== null && $maxPriority !== '') {
                 $consumer->setMaxPriority((int) $maxPriority);

--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -35,7 +35,7 @@ final class ConsumeCommand extends WorkCommand
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--max-priority=null : Maximum priority level to consume}
                             {--consumer-tag= : Custom RabbitMQ consumer tag}
-                            {--consume-mode=poll : Consumer mode: poll or consume}
+                            {--consume-mode= : Consumer mode: poll or consume}
                             {--num-processes=2 : Number of processes to run in parallel}
                            ';
 
@@ -129,7 +129,7 @@ final class ConsumeCommand extends WorkCommand
             $consumer->setContainer($this->laravel);
             $consumer->setName((string) $this->option('name'));
             $consumer->setConsumerTag($this->generateConsumerTag());
-            $consumer->setConsumeMode((string) $this->option('consume-mode'));
+            $consumer->setConsumeMode($this->consumeMode());
 
             $maxPriority = $this->option('max-priority');
             if ($maxPriority !== null && $maxPriority !== '') {
@@ -142,6 +142,17 @@ final class ConsumeCommand extends WorkCommand
 
             return 1;
         }
+    }
+
+    private function consumeMode(): string
+    {
+        $mode = $this->option('consume-mode');
+
+        if ($mode !== null && $mode !== '') {
+            return (string) $mode;
+        }
+
+        return (string) config('queue.connections.rabbitmq.options.queue.consume_mode', 'poll');
     }
 
     /**

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -27,6 +27,8 @@ class Consumer extends Worker
 
     private AMQPChannel $amqpChannel;
 
+    private string $consumeMode = 'poll';
+
     /**
      * The job currently being processed.
      *
@@ -52,6 +54,11 @@ class Consumer extends Worker
         $this->maxPriority = $value;
     }
 
+    public function setConsumeMode(string $mode): void
+    {
+        $this->consumeMode = in_array($mode, ['poll', 'consume'], true) ? $mode : 'poll';
+    }
+
     /**
      * Listen to the given queue in a loop.
      *
@@ -73,7 +80,6 @@ class Consumer extends Worker
 
         $connection = $this->manager->connection($connectionName);
 
-        // Check if the connection is a RabbitQueue instance
         if (! $connection instanceof RabbitQueue) {
             throw new RuntimeException('Connection must be an instance of RabbitQueue for RabbitMQ Consumer');
         }
@@ -85,27 +91,23 @@ class Consumer extends Worker
         $amqpQueue = new AMQPQueue($this->amqpChannel);
         $amqpQueue->setName($queue);
 
-        // Set QoS
-        $qosConfig = config('queue.connections.rabbitmq.options.queue.qos', []);
-        $prefetchCount = $qosConfig['prefetch_count'] ?? 10;
-        $prefetchSize = $qosConfig['prefetch_size'] ?? 0;
-        $global = $qosConfig['global'] ?? false;
+        $this->configureQos($queue);
 
-        $this->amqpChannel->setPrefetchCount($prefetchCount);
-        if ($prefetchSize > 0) {
-            $this->amqpChannel->setPrefetchSize($prefetchSize);
-        }
-
-        // Set consumer priority if configured
-        $queueConfig = config("queue.connections.rabbitmq.queues.{$queue}", []);
-        if (isset($queueConfig['priority'])) {
-            $this->setMaxPriority($queueConfig['priority']);
+        if ($this->consumeMode === 'consume') {
+            return $this->daemonUsingBasicConsume(
+                $amqpQueue,
+                $connection,
+                $jobClass,
+                $connectionName,
+                $queue,
+                $options,
+                $timestampOfLastQueueRestart,
+                $startTime,
+                $jobsProcessed
+            );
         }
 
         while (true) {
-            // Before reserving any jobs, we will make sure this queue is not paused and
-            // if it is we will just pause this worker for a given amount of time and
-            // make sure we do not need to kill this worker process off completely.
             if (! $this->daemonShouldRun($options, $connectionName, $queue)) {
                 $this->pauseWorker($options, $timestampOfLastQueueRestart);
 
@@ -113,36 +115,11 @@ class Consumer extends Worker
             }
 
             try {
-                // Try to get a message from the queue
                 $envelope = $amqpQueue->get(AMQP_NOPARAM);
 
                 if ($envelope instanceof AMQPEnvelope) {
-                    $job = new $jobClass(
-                        $this->container,
-                        $connection,
-                        $envelope,
-                        $connectionName,
-                        $queue
-                    );
-
-                    /** @var RabbitMQJob $job */
-                    $this->currentJob = $job;
-
-                    if ($this->supportsAsyncSignals()) {
-                        $this->registerTimeoutHandler($job, $options);
-                    }
-
-                    $jobsProcessed++;
-
-                    $this->runJob($job, $connectionName, $options);
-
-                    if ($this->supportsAsyncSignals()) {
-                        $this->resetTimeoutHandler();
-                    }
-
-                    $this->currentJob = null;
+                    $jobsProcessed += $this->processEnvelope($envelope, $connection, $jobClass, $connectionName, $queue, $options);
                 } else {
-                    // No job available, sleep for a bit
                     $this->sleep($options->sleep);
                 }
             } catch (AMQPChannelException|AMQPConnectionException $exception) {
@@ -153,9 +130,6 @@ class Consumer extends Worker
                 $this->stopWorkerIfLostConnection($exception);
             }
 
-            // Finally, we will check to see if we have exceeded our memory limits or if
-            // the queue should restart based on other indications. If so, we'll stop
-            // this worker and let whatever is "monitoring" it restart the process.
             $status = $this->stopIfNecessary(
                 $options,
                 $timestampOfLastQueueRestart,
@@ -167,6 +141,117 @@ class Consumer extends Worker
             if (! is_null($status)) {
                 return $this->stop($status);
             }
+        }
+    }
+
+    /**
+     * @param  class-string<RabbitMQJob>  $jobClass
+     */
+    private function daemonUsingBasicConsume(
+        AMQPQueue $amqpQueue,
+        RabbitQueue $connection,
+        string $jobClass,
+        string $connectionName,
+        string $queue,
+        WorkerOptions $options,
+        int $timestampOfLastQueueRestart,
+        float $startTime,
+        int &$jobsProcessed
+    ): int {
+        $callback = function (AMQPEnvelope $envelope) use (
+            $connection,
+            $jobClass,
+            $connectionName,
+            $queue,
+            $options,
+            $timestampOfLastQueueRestart,
+            $startTime,
+            &$jobsProcessed
+        ): bool {
+            if (! $this->daemonShouldRun($options, $connectionName, $queue)) {
+                $this->pauseWorker($options, $timestampOfLastQueueRestart);
+
+                return true;
+            }
+
+            try {
+                $jobsProcessed += $this->processEnvelope($envelope, $connection, $jobClass, $connectionName, $queue, $options);
+            } catch (Throwable $exception) {
+                $this->exceptions->report($exception);
+                $this->stopWorkerIfLostConnection($exception);
+            }
+
+            $status = $this->stopIfNecessary(
+                $options,
+                $timestampOfLastQueueRestart,
+                $startTime,
+                $jobsProcessed,
+                $this->currentJob
+            );
+
+            return is_null($status);
+        };
+
+        try {
+            $amqpQueue->consume($callback, AMQP_NOPARAM, $this->consumerTag ?: null);
+        } catch (AMQPChannelException|AMQPConnectionException $exception) {
+            $this->exceptions->report($exception);
+            $this->stopWorkerIfLostConnection($exception);
+        }
+
+        return $this->stop(0);
+    }
+
+    /**
+     * @param  class-string<RabbitMQJob>  $jobClass
+     */
+    private function processEnvelope(
+        AMQPEnvelope $envelope,
+        RabbitQueue $connection,
+        string $jobClass,
+        string $connectionName,
+        string $queue,
+        WorkerOptions $options
+    ): int {
+        $job = new $jobClass(
+            $this->container,
+            $connection,
+            $envelope,
+            $connectionName,
+            $queue
+        );
+
+        $this->currentJob = $job;
+
+        if ($this->supportsAsyncSignals()) {
+            $this->registerTimeoutHandler($job, $options);
+        }
+
+        $this->runJob($job, $connectionName, $options);
+
+        if ($this->supportsAsyncSignals()) {
+            $this->resetTimeoutHandler();
+        }
+
+        $this->currentJob = null;
+
+        return 1;
+    }
+
+    private function configureQos(string $queue): void
+    {
+        $qosConfig = config('queue.connections.rabbitmq.options.queue.qos', []);
+        $prefetchCount = $qosConfig['prefetch_count'] ?? 10;
+        $prefetchSize = $qosConfig['prefetch_size'] ?? 0;
+
+        $this->amqpChannel->setPrefetchCount($prefetchCount);
+        if ($prefetchSize > 0) {
+            $this->amqpChannel->setPrefetchSize($prefetchSize);
+        }
+
+        $queueConfig = config("queue.connections.rabbitmq.queues.{$queue}", []);
+        if (isset($queueConfig['priority'])) {
+            $this->setMaxPriority((int) $queueConfig['priority']);
         }
     }
 
@@ -183,9 +268,6 @@ class Consumer extends Worker
 
     public function stop($status = 0, $options = null, $reason = null)
     {
-        // For ext-amqp, we don't need to explicitly cancel consumption
-        // as we're using a polling approach rather than a callback approach
-
         return parent::stop($status, $options, $reason);
     }
 }

--- a/src/Horizon/HorizonRabbitQueue.php
+++ b/src/Horizon/HorizonRabbitQueue.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelRabbitMQ\Horizon;
+
+use iamfarhad\LaravelRabbitMQ\Jobs\RabbitMQJob;
+use iamfarhad\LaravelRabbitMQ\RabbitQueue;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class HorizonRabbitQueue extends RabbitQueue
+{
+    private string|object|null $lastPushed = null;
+
+    public function readyNow(?string $queue = null): int
+    {
+        return $this->size($queue);
+    }
+
+    public function push($job, $data = '', $queue = null): ?string
+    {
+        $this->lastPushed = $job;
+
+        return parent::push($job, $data, $queue);
+    }
+
+    public function pushRaw($payload, $queue = null, array $options = []): ?string
+    {
+        $payload = $this->prepareHorizonPayload((string) $payload, $this->lastPushed);
+        $queueName = $this->getQueue($queue);
+
+        $this->dispatchHorizonEvent($queueName, \Laravel\Horizon\Events\JobPending::class, [$payload]);
+
+        return tap(parent::pushRaw($payload, $queue, $options), function () use ($queueName, $payload): void {
+            $this->dispatchHorizonEvent($queueName, \Laravel\Horizon\Events\JobPushed::class, [$payload]);
+        });
+    }
+
+    public function later($delay, $job, $data = '', $queue = null): ?string
+    {
+        $payload = $this->prepareHorizonPayload(
+            $this->createPayload($job, $this->getQueue($queue), $data),
+            $job
+        );
+        $queueName = $this->getQueue($queue);
+
+        $this->dispatchHorizonEvent($queueName, \Laravel\Horizon\Events\JobPending::class, [$payload]);
+
+        return tap(parent::laterRaw($delay, $payload, $queue), function () use ($queueName, $payload): void {
+            $this->dispatchHorizonEvent($queueName, \Laravel\Horizon\Events\JobPushed::class, [$payload]);
+        });
+    }
+
+    public function pop($queue = null)
+    {
+        return tap(parent::pop($queue), function ($job) use ($queue): void {
+            if ($job instanceof RabbitMQJob) {
+                $this->dispatchHorizonEvent(
+                    $this->getQueue($queue),
+                    \Laravel\Horizon\Events\JobReserved::class,
+                    [$job->getRawBody()]
+                );
+            }
+        });
+    }
+
+    public function deleteReserved($queue, $job): void
+    {
+        if ($job instanceof RabbitMQJob) {
+            $this->dispatchHorizonEvent(
+                $this->getQueue($queue),
+                \Laravel\Horizon\Events\JobDeleted::class,
+                [$job, $job->getRawBody()]
+            );
+        }
+    }
+
+    private function prepareHorizonPayload(string $payload, string|object|null $job): string
+    {
+        if (! class_exists(\Laravel\Horizon\JobPayload::class)) {
+            return $payload;
+        }
+
+        return (new \Laravel\Horizon\JobPayload($payload))->prepare($job)->value;
+    }
+
+    /**
+     * @param  array<int, mixed>  $arguments
+     */
+    private function dispatchHorizonEvent(string $queue, string $eventClass, array $arguments): void
+    {
+        if (! class_exists($eventClass) || ! $this->container || ! $this->container->bound(Dispatcher::class)) {
+            return;
+        }
+
+        $event = new $eventClass(...$arguments);
+
+        $this->container->make(Dispatcher::class)->dispatch(
+            $event->connection($this->getConnectionName())->queue($queue)
+        );
+    }
+}

--- a/src/Horizon/HorizonRabbitQueue.php
+++ b/src/Horizon/HorizonRabbitQueue.php
@@ -10,6 +10,16 @@ use Illuminate\Contracts\Events\Dispatcher;
 
 class HorizonRabbitQueue extends RabbitQueue
 {
+    private const HORIZON_JOB_PAYLOAD = 'Laravel\\Horizon\\JobPayload';
+
+    private const HORIZON_JOB_PENDING = 'Laravel\\Horizon\\Events\\JobPending';
+
+    private const HORIZON_JOB_PUSHED = 'Laravel\\Horizon\\Events\\JobPushed';
+
+    private const HORIZON_JOB_RESERVED = 'Laravel\\Horizon\\Events\\JobReserved';
+
+    private const HORIZON_JOB_DELETED = 'Laravel\\Horizon\\Events\\JobDeleted';
+
     private string|object|null $lastPushed = null;
 
     public function readyNow(?string $queue = null): int
@@ -29,10 +39,10 @@ class HorizonRabbitQueue extends RabbitQueue
         $payload = $this->prepareHorizonPayload((string) $payload, $this->lastPushed);
         $queueName = $this->getQueue($queue);
 
-        $this->dispatchHorizonEvent($queueName, \Laravel\Horizon\Events\JobPending::class, [$payload]);
+        $this->dispatchHorizonEvent($queueName, self::HORIZON_JOB_PENDING, [$payload]);
 
         return tap(parent::pushRaw($payload, $queue, $options), function () use ($queueName, $payload): void {
-            $this->dispatchHorizonEvent($queueName, \Laravel\Horizon\Events\JobPushed::class, [$payload]);
+            $this->dispatchHorizonEvent($queueName, self::HORIZON_JOB_PUSHED, [$payload]);
         });
     }
 
@@ -44,10 +54,10 @@ class HorizonRabbitQueue extends RabbitQueue
         );
         $queueName = $this->getQueue($queue);
 
-        $this->dispatchHorizonEvent($queueName, \Laravel\Horizon\Events\JobPending::class, [$payload]);
+        $this->dispatchHorizonEvent($queueName, self::HORIZON_JOB_PENDING, [$payload]);
 
         return tap(parent::laterRaw($delay, $payload, $queue), function () use ($queueName, $payload): void {
-            $this->dispatchHorizonEvent($queueName, \Laravel\Horizon\Events\JobPushed::class, [$payload]);
+            $this->dispatchHorizonEvent($queueName, self::HORIZON_JOB_PUSHED, [$payload]);
         });
     }
 
@@ -57,7 +67,7 @@ class HorizonRabbitQueue extends RabbitQueue
             if ($job instanceof RabbitMQJob) {
                 $this->dispatchHorizonEvent(
                     $this->getQueue($queue),
-                    \Laravel\Horizon\Events\JobReserved::class,
+                    self::HORIZON_JOB_RESERVED,
                     [$job->getRawBody()]
                 );
             }
@@ -69,7 +79,7 @@ class HorizonRabbitQueue extends RabbitQueue
         if ($job instanceof RabbitMQJob) {
             $this->dispatchHorizonEvent(
                 $this->getQueue($queue),
-                \Laravel\Horizon\Events\JobDeleted::class,
+                self::HORIZON_JOB_DELETED,
                 [$job, $job->getRawBody()]
             );
         }
@@ -77,11 +87,11 @@ class HorizonRabbitQueue extends RabbitQueue
 
     private function prepareHorizonPayload(string $payload, string|object|null $job): string
     {
-        if (! class_exists(\Laravel\Horizon\JobPayload::class)) {
+        if (! class_exists(self::HORIZON_JOB_PAYLOAD)) {
             return $payload;
         }
 
-        return (new \Laravel\Horizon\JobPayload($payload))->prepare($job)->value;
+        return (new (self::HORIZON_JOB_PAYLOAD)($payload))->prepare($job)->value;
     }
 
     /**

--- a/src/Horizon/Listeners/RabbitMQFailedEvent.php
+++ b/src/Horizon/Listeners/RabbitMQFailedEvent.php
@@ -12,9 +12,7 @@ class RabbitMQFailedEvent
 {
     private const HORIZON_JOB_FAILED = 'Laravel\\Horizon\\Events\\JobFailed';
 
-    public function __construct(private Dispatcher $events)
-    {
-    }
+    public function __construct(private Dispatcher $events) {}
 
     public function handle(LaravelJobFailed $event): void
     {

--- a/src/Horizon/Listeners/RabbitMQFailedEvent.php
+++ b/src/Horizon/Listeners/RabbitMQFailedEvent.php
@@ -10,16 +10,20 @@ use Illuminate\Queue\Events\JobFailed as LaravelJobFailed;
 
 class RabbitMQFailedEvent
 {
-    public function __construct(private Dispatcher $events) {}
+    private const HORIZON_JOB_FAILED = 'Laravel\\Horizon\\Events\\JobFailed';
+
+    public function __construct(private Dispatcher $events)
+    {
+    }
 
     public function handle(LaravelJobFailed $event): void
     {
-        if (! $event->job instanceof RabbitMQJob || ! class_exists(\Laravel\Horizon\Events\JobFailed::class)) {
+        if (! $event->job instanceof RabbitMQJob || ! class_exists(self::HORIZON_JOB_FAILED)) {
             return;
         }
 
         $this->events->dispatch(
-            (new \Laravel\Horizon\Events\JobFailed(
+            (new (self::HORIZON_JOB_FAILED)(
                 $event->exception,
                 $event->job,
                 $event->job->getRawBody()

--- a/src/Horizon/Listeners/RabbitMQFailedEvent.php
+++ b/src/Horizon/Listeners/RabbitMQFailedEvent.php
@@ -18,7 +18,7 @@ class RabbitMQFailedEvent
 
     public function handle(LaravelJobFailed $event): void
     {
-        if (! $event->job instanceof RabbitMQJob || ! class_exists(self::HORIZON_JOB_FAILED)) {
+        if (!$event->job instanceof RabbitMQJob || !class_exists(self::HORIZON_JOB_FAILED)) {
             return;
         }
 

--- a/src/Horizon/Listeners/RabbitMQFailedEvent.php
+++ b/src/Horizon/Listeners/RabbitMQFailedEvent.php
@@ -18,7 +18,7 @@ class RabbitMQFailedEvent
 
     public function handle(LaravelJobFailed $event): void
     {
-        if (!$event->job instanceof RabbitMQJob || !class_exists(self::HORIZON_JOB_FAILED)) {
+        if (! $event->job instanceof RabbitMQJob || ! class_exists(self::HORIZON_JOB_FAILED)) {
             return;
         }
 

--- a/src/Horizon/Listeners/RabbitMQFailedEvent.php
+++ b/src/Horizon/Listeners/RabbitMQFailedEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelRabbitMQ\Horizon\Listeners;
+
+use iamfarhad\LaravelRabbitMQ\Jobs\RabbitMQJob;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Events\JobFailed as LaravelJobFailed;
+
+class RabbitMQFailedEvent
+{
+    public function __construct(private Dispatcher $events) {}
+
+    public function handle(LaravelJobFailed $event): void
+    {
+        if (! $event->job instanceof RabbitMQJob || ! class_exists(\Laravel\Horizon\Events\JobFailed::class)) {
+            return;
+        }
+
+        $this->events->dispatch(
+            (new \Laravel\Horizon\Events\JobFailed(
+                $event->exception,
+                $event->job,
+                $event->job->getRawBody()
+            ))->connection($event->connectionName)->queue($event->job->getQueue())
+        );
+    }
+}

--- a/src/LaravelRabbitQueueServiceProvider.php
+++ b/src/LaravelRabbitQueueServiceProvider.php
@@ -3,7 +3,11 @@
 namespace iamfarhad\LaravelRabbitMQ;
 
 use iamfarhad\LaravelRabbitMQ\Connectors\RabbitMQConnector;
+use iamfarhad\LaravelRabbitMQ\Console\Commands\ExchangeDeclareCommand;
 use iamfarhad\LaravelRabbitMQ\Console\Commands\PoolStatsCommand;
+use iamfarhad\LaravelRabbitMQ\Console\Commands\QueueDeclareCommand;
+use iamfarhad\LaravelRabbitMQ\Console\Commands\QueueDeleteCommand;
+use iamfarhad\LaravelRabbitMQ\Console\Commands\QueuePurgeCommand;
 use iamfarhad\LaravelRabbitMQ\Console\ConsumeCommand;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Queue\QueueManager;
@@ -42,6 +46,10 @@ final class LaravelRabbitQueueServiceProvider extends ServiceProvider
             $this->commands([
                 ConsumeCommand::class,
                 PoolStatsCommand::class,
+                ExchangeDeclareCommand::class,
+                QueueDeclareCommand::class,
+                QueuePurgeCommand::class,
+                QueueDeleteCommand::class,
             ]);
         }
     }

--- a/src/RabbitQueue.php
+++ b/src/RabbitQueue.php
@@ -107,8 +107,10 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
             return $amqpQueue->declareQueue();
         } catch (AMQPChannelException $exception) {
-            // If queue doesn't exist
+            // Passive declarations close the channel when the queue is missing.
             if ($exception->getCode() === self::QUEUE_NOT_FOUND_CODE) {
+                $this->releaseChannel();
+
                 return 0;
             }
 
@@ -337,7 +339,9 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
             return true;
         } catch (Throwable $throwable) {
-            if ($throwable instanceof AMQPChannelException && $throwable->getCode() === 404) {
+            if ($throwable instanceof AMQPChannelException && $throwable->getCode() === self::QUEUE_NOT_FOUND_CODE) {
+                $this->releaseChannel();
+
                 return false;
             }
 

--- a/src/RabbitQueue.php
+++ b/src/RabbitQueue.php
@@ -30,17 +30,27 @@ use Throwable;
 class RabbitQueue extends Queue implements RabbitQueueInterface
 {
     private const DELIVERY_MODE_PERSISTENT = 2;
+
     private const QUEUE_NOT_FOUND_CODE = 404;
+
     private const QUEUE_ALREADY_EXISTS_CODE = 406;
+
     private const DEFAULT_RETRY_DELAY = 1000;
+
     private const MAX_RETRY_ATTEMPTS = 3;
 
     private ?AMQPChannel $amqpChannel = null;
+
     private ?RabbitMQJob $rabbitMQJob = null;
+
     private ?ExchangeManager $exchangeManager = null;
+
     private ?ExponentialBackoff $backoff = null;
+
     private ?PublisherConfirms $publisherConfirms = null;
+
     private ?TransactionManager $transactionManager = null;
+
     private ?RpcClient $rpcClient = null;
 
     public function __construct(

--- a/src/RabbitQueue.php
+++ b/src/RabbitQueue.php
@@ -202,7 +202,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         try {
             $queueName = $this->getQueue($queue);
 
-            if (!$this->queueExists($queueName)) {
+            if (! $this->queueExists($queueName)) {
                 $this->declareQueue($queueName);
             }
 
@@ -274,7 +274,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
     public function close(): void
     {
-        if ($this->rabbitMQJob !== null && !$this->rabbitMQJob->isDeletedOrReleased()) {
+        if ($this->rabbitMQJob !== null && ! $this->rabbitMQJob->isDeletedOrReleased()) {
             $this->reject($this->rabbitMQJob, true);
         }
 
@@ -362,7 +362,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         /** @var class-string<RabbitMQJob> $job */
         $job = config('queue.connections.rabbitmq.options.queue.job', RabbitMQJob::class);
 
-        if (!is_string($job) || !is_a($job, RabbitMQJob::class, true)) {
+        if (! is_string($job) || ! is_a($job, RabbitMQJob::class, true)) {
             throw new Exception(sprintf('Class %s must extend: %s', is_string($job) ? $job : gettype($job), RabbitMQJob::class));
         }
 
@@ -626,7 +626,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
     public function rpcCall(string $queue, string $message, array $headers = []): string
     {
-        if (!$this->isRpcEnabled()) {
+        if (! $this->isRpcEnabled()) {
             throw new Exception('RPC is not enabled in configuration');
         }
 
@@ -635,7 +635,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
     public function transaction(callable $callback): mixed
     {
-        if (!$this->isTransactionsEnabled()) {
+        if (! $this->isTransactionsEnabled()) {
             throw new Exception('Transactions are not enabled in configuration');
         }
 
@@ -652,7 +652,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         }
 
         $priority = $queueConfig['priority'] ?? ($this->shouldPrioritizeDelayed() ? $this->getQueueMaxPriority() : null);
-        if (is_numeric($priority) && (int) $priority > 0 && !$this->isQuorumQueue($queueConfig)) {
+        if (is_numeric($priority) && (int) $priority > 0 && ! $this->isQuorumQueue($queueConfig)) {
             $arguments['x-max-priority'] = min((int) $priority, 255);
         }
 
@@ -736,7 +736,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
     ): void {
         $dlxConfig = config('queue.connections.rabbitmq.dead_letter', []);
 
-        if (!($dlxConfig['enabled'] ?? true)) {
+        if (! ($dlxConfig['enabled'] ?? true)) {
             return;
         }
 

--- a/src/RabbitQueue.php
+++ b/src/RabbitQueue.php
@@ -21,7 +21,6 @@ use iamfarhad\LaravelRabbitMQ\Support\MessageHelpers;
 use iamfarhad\LaravelRabbitMQ\Support\PublisherConfirms;
 use iamfarhad\LaravelRabbitMQ\Support\RpcClient;
 use iamfarhad\LaravelRabbitMQ\Support\TransactionManager;
-use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Arr;
 use JsonException;
@@ -203,7 +202,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         try {
             $queueName = $this->getQueue($queue);
 
-            if (! $this->queueExists($queueName)) {
+            if (!$this->queueExists($queueName)) {
                 $this->declareQueue($queueName);
             }
 
@@ -275,7 +274,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
     public function close(): void
     {
-        if ($this->rabbitMQJob !== null && ! $this->rabbitMQJob->isDeletedOrReleased()) {
+        if ($this->rabbitMQJob !== null && !$this->rabbitMQJob->isDeletedOrReleased()) {
             $this->reject($this->rabbitMQJob, true);
         }
 
@@ -363,7 +362,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         /** @var class-string<RabbitMQJob> $job */
         $job = config('queue.connections.rabbitmq.options.queue.job', RabbitMQJob::class);
 
-        if (! is_string($job) || ! is_a($job, RabbitMQJob::class, true)) {
+        if (!is_string($job) || !is_a($job, RabbitMQJob::class, true)) {
             throw new Exception(sprintf('Class %s must extend: %s', is_string($job) ? $job : gettype($job), RabbitMQJob::class));
         }
 
@@ -627,7 +626,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
     public function rpcCall(string $queue, string $message, array $headers = []): string
     {
-        if (! $this->isRpcEnabled()) {
+        if (!$this->isRpcEnabled()) {
             throw new Exception('RPC is not enabled in configuration');
         }
 
@@ -636,7 +635,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
     public function transaction(callable $callback): mixed
     {
-        if (! $this->isTransactionsEnabled()) {
+        if (!$this->isTransactionsEnabled()) {
             throw new Exception('Transactions are not enabled in configuration');
         }
 
@@ -653,7 +652,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         }
 
         $priority = $queueConfig['priority'] ?? ($this->shouldPrioritizeDelayed() ? $this->getQueueMaxPriority() : null);
-        if (is_numeric($priority) && (int) $priority > 0 && ! $this->isQuorumQueue($queueConfig)) {
+        if (is_numeric($priority) && (int) $priority > 0 && !$this->isQuorumQueue($queueConfig)) {
             $arguments['x-max-priority'] = min((int) $priority, 255);
         }
 
@@ -737,7 +736,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
     ): void {
         $dlxConfig = config('queue.connections.rabbitmq.dead_letter', []);
 
-        if (! ($dlxConfig['enabled'] ?? true)) {
+        if (!($dlxConfig['enabled'] ?? true)) {
             return;
         }
 

--- a/src/RabbitQueue.php
+++ b/src/RabbitQueue.php
@@ -30,27 +30,17 @@ use Throwable;
 class RabbitQueue extends Queue implements RabbitQueueInterface
 {
     private const DELIVERY_MODE_PERSISTENT = 2;
-
     private const QUEUE_NOT_FOUND_CODE = 404;
-
     private const QUEUE_ALREADY_EXISTS_CODE = 406;
-
     private const DEFAULT_RETRY_DELAY = 1000;
-
     private const MAX_RETRY_ATTEMPTS = 3;
 
     private ?AMQPChannel $amqpChannel = null;
-
     private ?RabbitMQJob $rabbitMQJob = null;
-
     private ?ExchangeManager $exchangeManager = null;
-
     private ?ExponentialBackoff $backoff = null;
-
     private ?PublisherConfirms $publisherConfirms = null;
-
     private ?TransactionManager $transactionManager = null;
-
     private ?RpcClient $rpcClient = null;
 
     public function __construct(
@@ -69,9 +59,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $this->poolManager->getConnection();
     }
 
-    /**
-     * Get a channel from the pool
-     */
     public function getChannel(): AMQPChannel
     {
         if ($this->amqpChannel === null) {
@@ -81,9 +68,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $this->amqpChannel;
     }
 
-    /**
-     * Release the current channel back to the pool
-     */
     private function releaseChannel(): void
     {
         if ($this->amqpChannel !== null) {
@@ -100,14 +84,12 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         $queueName = $this->getQueue($queue);
 
         try {
-            $channel = $this->getChannel();
-            $amqpQueue = new AMQPQueue($channel);
+            $amqpQueue = new AMQPQueue($this->getChannel());
             $amqpQueue->setName($queueName);
             $amqpQueue->setFlags(AMQP_PASSIVE);
 
             return $amqpQueue->declareQueue();
         } catch (AMQPChannelException $exception) {
-            // Passive declarations close the channel when the queue is missing.
             if ($exception->getCode() === self::QUEUE_NOT_FOUND_CODE) {
                 $this->releaseChannel();
 
@@ -118,63 +100,26 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         }
     }
 
-    /**
-     * Get the number of pending jobs.
-     *
-     * Laravel 13 added queue metrics to the queue contract. RabbitMQ's passive
-     * queue declaration returns the number of ready messages, which maps to
-     * Laravel's pending job count.
-     *
-     * @throws AMQPChannelException
-     */
     public function pendingSize($queue = null): int
     {
         return $this->size($queue);
     }
 
-    /**
-     * Get the number of delayed jobs.
-     *
-     * This driver implements delays through per-delay TTL queues. RabbitMQ does
-     * not provide a single aggregate delayed count for the target queue, so this
-     * returns 0 rather than reporting an inaccurate value.
-     */
     public function delayedSize($queue = null): int
     {
         return 0;
     }
 
-    /**
-     * Get the number of reserved jobs.
-     *
-     * Reserved jobs are represented as unacknowledged RabbitMQ deliveries and
-     * are not exposed by a passive queue declaration in this driver.
-     */
     public function reservedSize($queue = null): int
     {
         return 0;
     }
 
-    /**
-     * Get the creation timestamp of the oldest pending job.
-     *
-     * RabbitMQ does not expose the creation time of the oldest ready message
-     * without consuming it, so this metric is unavailable.
-     */
     public function creationTimeOfOldestPendingJob($queue = null): ?int
     {
         return null;
     }
 
-    /**
-     * Push a new job onto the queue.
-     *
-     * @param  mixed  $job
-     * @param  mixed  $data
-     * @param  string|null  $queue
-     *
-     * @throws JsonException
-     */
     public function push($job, $data = '', $queue = null): ?string
     {
         return $this->enqueueUsing(
@@ -187,33 +132,18 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
     }
 
     /**
-     * Push a raw payload onto the queue.
-     *
-     * @param  string  $payload
-     * @param  string|null  $queue
-     *
      * @throws JsonException
      */
     public function pushRaw($payload, $queue = null, array $options = []): ?string
     {
         $queueName = $this->getQueue($queue);
-        $attempts = Arr::get($options, 'attempts', 0);
+        $attempts = (int) Arr::get($options, 'attempts', 0);
 
-        $this->declareQueue($queueName);
+        $this->declareDestination($queueName, $options);
 
-        return $this->publishMessage($payload, $queueName, $attempts);
+        return $this->publishMessage($payload, $queueName, $attempts, $options);
     }
 
-    /**
-     * Push a new job onto the queue after a delay.
-     *
-     * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  mixed  $job
-     * @param  mixed  $data
-     * @param  string|null  $queue
-     *
-     * @throws JsonException
-     */
     public function later($delay, $job, $data = '', $queue = null): ?string
     {
         return $this->enqueueUsing(
@@ -226,46 +156,43 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
     }
 
     /**
-     * Push a raw job onto the queue after a delay.
-     *
-     * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  string  $payload
-     * @param  string|null  $queue
-     * @param  int  $attempts
-     *
      * @throws JsonException|AMQPChannelException
      */
     public function laterRaw($delay, $payload, $queue = null, $attempts = 2): ?string
     {
         $ttl = $this->secondsUntil($delay) * 1000;
+        $options = ['delay' => $delay, 'attempts' => $attempts];
 
-        // When no ttl just publish a new message to the queue
         if ($ttl <= 0) {
-            return $this->pushRaw($payload, $queue, ['delay' => $delay, 'attempts' => $attempts]);
+            return $this->pushRaw($payload, $queue, $options);
         }
 
         $queueName = $this->getQueue($queue);
         $delayQueueName = $queueName.'.delay.'.$ttl;
 
+        $this->declareDestination($queueName, $options);
         $this->declareDelayQueue($delayQueueName, $queueName, $ttl);
 
-        return $this->publishMessage($payload, $delayQueueName, $attempts);
+        return $this->publishMessage($payload, $delayQueueName, (int) $attempts, $options + ['exchange' => '']);
     }
 
     /**
-     * Pop the next job off of the queue.
+     * Publish many jobs while reusing declared topology and channel state.
      *
-     * @param  string|null  $queue
-     * @return Job|null
-     *
-     * @throws AMQPChannelException|Throwable
+     * @param  iterable<mixed>  $jobs
      */
+    public function bulk($jobs, $data = '', $queue = null): void
+    {
+        foreach ($jobs as $job) {
+            $this->push($job, $data, $queue);
+        }
+    }
+
     public function pop($queue = null)
     {
         try {
             $queueName = $this->getQueue($queue);
 
-            // Create queue if it doesn't exist yet
             if (! $this->queueExists($queueName)) {
                 $this->declareQueue($queueName);
             }
@@ -275,8 +202,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
             $amqpQueue = new AMQPQueue($this->getChannel());
             $amqpQueue->setName($queueName);
 
-            // Use AMQP_NOPARAM to get message without auto-ack
-            // This allows the job to manually acknowledge after processing
             if (($envelope = $amqpQueue->get(AMQP_NOPARAM)) !== false && $envelope !== null) {
                 $this->rabbitMQJob = new $jobClass(
                     $this->container,
@@ -291,12 +216,9 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
             return null;
         } catch (AMQPChannelException $exception) {
-            // If there is no queue AMQP will throw exception with code 404
             if ($exception->getCode() === self::QUEUE_NOT_FOUND_CODE) {
-                // Create a new channel since the old one is closed
                 $this->releaseChannel();
 
-                // Try to create the queue and retry
                 try {
                     $this->declareQueue($queueName);
 
@@ -308,7 +230,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
             throw $exception;
         } catch (AMQPConnectionException $exception) {
-            // Replace with a more specific exception that Laravel's worker can detect as a lost connection
             throw new Exception(
                 'Lost connection: '.$exception->getMessage(),
                 $exception->getCode(),
@@ -317,22 +238,15 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         }
     }
 
-    /**
-     * Get the queue name.
-     */
     public function getQueue(?string $queue = null): string
     {
         return $queue ?? $this->defaultQueue;
     }
 
-    /**
-     * Check if a queue exists.
-     */
     public function queueExists(string $queueName): bool
     {
         try {
-            $channel = $this->getChannel();
-            $amqpQueue = new AMQPQueue($channel);
+            $amqpQueue = new AMQPQueue($this->getChannel());
             $amqpQueue->setName($queueName);
             $amqpQueue->setFlags(AMQP_PASSIVE);
             $amqpQueue->declareQueue();
@@ -345,46 +259,29 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
                 return false;
             }
 
-            // If another error occurred, we'll assume the queue doesn't exist
-            // to avoid false positives
             return false;
         }
     }
 
-    /**
-     * Close the connection and release resources.
-     */
     public function close(): void
     {
         if ($this->rabbitMQJob !== null && ! $this->rabbitMQJob->isDeletedOrReleased()) {
             $this->reject($this->rabbitMQJob, true);
         }
 
-        // Release the channel back to the pool
         $this->releaseChannel();
     }
 
-    /**
-     * Get the current AMQP channel (public API).
-     */
     public function getAmqpChannel(): AMQPChannel
     {
         return $this->getChannel();
     }
 
-    /**
-     * Generate a random ID.
-     */
     private function getRandomId(): string
     {
         return MessageHelpers::generateCorrelationId();
     }
 
-    /**
-     * Declare a queue.
-     *
-     * @throws AMQPChannelException
-     */
     public function declareQueue(
         string $name,
         bool $durable = true,
@@ -392,10 +289,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         array $arguments = []
     ): void {
         try {
-            // Connection health is managed by the pool
-
-            // Channel health is managed by the pool
-
             $amqpQueue = new AMQPQueue($this->getChannel());
             $amqpQueue->setName($name);
             $amqpQueue->setFlags($durable ? AMQP_DURABLE : AMQP_NOPARAM);
@@ -404,44 +297,57 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
                 $amqpQueue->setFlags($amqpQueue->getFlags() | AMQP_AUTODELETE);
             }
 
-            if (! empty($arguments)) {
+            $arguments = array_merge($this->getQueueArguments($name), $arguments);
+            if ($arguments !== []) {
                 $amqpQueue->setArguments($arguments);
             }
 
             $amqpQueue->declareQueue();
         } catch (AMQPChannelException|AMQPQueueException $exception) {
-            // If it's not a "queue already exists" or "unknown delivery tag" case, re-throw
             if ($exception->getCode() !== self::QUEUE_ALREADY_EXISTS_CODE) {
                 throw $exception;
             }
-            // Ignore 406 errors (queue already exists or unknown delivery tag)
-        } catch (AMQPConnectionException $exception) {
-            // Reopen channel and try again
+        } catch (AMQPConnectionException) {
             $this->releaseChannel();
             $this->declareQueue($name, $durable, $autoDelete, $arguments);
         }
     }
 
-    /**
-     * Declare a delay queue with TTL.
-     */
+    private function declareDestination(string $queueName, array $options = []): void
+    {
+        $exchange = $this->getExchange(Arr::get($options, 'exchange'));
+
+        if ($exchange !== '') {
+            $this->declareExchange($exchange, $this->getExchangeType(Arr::get($options, 'exchange_type')));
+
+            return;
+        }
+
+        $this->declareQueue($queueName);
+    }
+
+    private function declareExchange(string $name, string $type = AMQP_EX_TYPE_DIRECT): void
+    {
+        $exchange = new AMQPExchange($this->getChannel());
+        $exchange->setName($name);
+        $exchange->setType($type);
+        $exchange->setFlags(AMQP_DURABLE);
+        $exchange->declareExchange();
+    }
+
     private function declareDelayQueue(string $delayQueueName, string $targetQueueName, int $ttl): void
     {
         $arguments = [
             'x-message-ttl' => $ttl,
-            'x-dead-letter-exchange' => '',
-            'x-dead-letter-routing-key' => $targetQueueName,
+            'x-expires' => max($ttl * 2, $ttl + 1000),
+            'x-dead-letter-exchange' => $this->getExchange(),
+            'x-dead-letter-routing-key' => $this->getRoutingKey($targetQueueName),
         ];
 
         $this->declareQueue($delayQueueName, true, false, $arguments);
-        $this->declareQueue($targetQueueName); // Ensure target queue exists
+        $this->declareDestination($targetQueueName);
     }
 
-    /**
-     * Get the job class.
-     *
-     * @throws Throwable
-     */
     public function getJobClass(): string
     {
         /** @var class-string<RabbitMQJob> $job */
@@ -454,9 +360,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $job;
     }
 
-    /**
-     * Reject a job.
-     */
     public function reject(RabbitMQJob $rabbitMQJob, bool $requeue = false): void
     {
         $envelope = $rabbitMQJob->getRabbitMQMessage();
@@ -470,8 +373,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
             $amqpQueue = new AMQPQueue($this->getChannel());
             $amqpQueue->setName($rabbitMQJob->getQueue());
             $amqpQueue->reject($deliveryTag, $requeue ? AMQP_REQUEUE : AMQP_NOPARAM);
-        } catch (AMQPChannelException|AMQPConnectionException $exception) {
-            // Reopen channel and try again
+        } catch (AMQPChannelException|AMQPConnectionException) {
             $this->releaseChannel();
             $amqpQueue = new AMQPQueue($this->getChannel());
             $amqpQueue->setName($rabbitMQJob->getQueue());
@@ -479,9 +381,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         }
     }
 
-    /**
-     * Acknowledge a job with retry logic.
-     */
     public function ack(RabbitMQJob $rabbitMQJob, int $maxRetries = self::MAX_RETRY_ATTEMPTS, int $retryDelay = self::DEFAULT_RETRY_DELAY): void
     {
         $envelope = $rabbitMQJob->getRabbitMQMessage();
@@ -499,50 +398,29 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
                 $amqpQueue->setName($rabbitMQJob->getQueue());
                 $amqpQueue->ack($deliveryTag);
 
-                return; // Acknowledgment successful
-            } catch (AMQPChannelException|AMQPConnectionException $exception) {
-                // Recreate channel instead of setting to null
+                return;
+            } catch (AMQPChannelException|AMQPConnectionException) {
                 $this->releaseChannel();
                 $attempts++;
                 if ($attempts < $maxRetries) {
-                    usleep($retryDelay * 1000); // Wait before retrying
+                    usleep($retryDelay * 1000);
                 }
-            } catch (Throwable $e) {
-
-                break; // Stop retrying for other errors
+            } catch (Throwable) {
+                break;
             }
         }
     }
 
-    /**
-     * Set queue options.
-     */
     public function setOptions(array $options): void
     {
         $this->options = $options;
     }
 
-    /**
-     * Create a message.
-     *
-     * @param  string  $payload
-     *
-     * @throws JsonException
-     */
     public function createMessage($payload, int $attempts = 2): string
     {
-        $correlationId = null;
-
-        $correlationId = MessageHelpers::extractCorrelationId($payload) ?? $this->getRandomId();
-
-        return $correlationId;
+        return MessageHelpers::extractCorrelationId($payload) ?? $this->getRandomId();
     }
 
-    /**
-     * Purge a queue.
-     *
-     * @return mixed
-     */
     public function purgeQueue(string $queueName)
     {
         try {
@@ -551,25 +429,18 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
             return $amqpQueue->purge();
         } catch (AMQPChannelException $exception) {
-            // If queue doesn't exist, just return
             if ($exception->getCode() === self::QUEUE_NOT_FOUND_CODE) {
                 return null;
             }
 
             throw $exception;
-        } catch (AMQPConnectionException $exception) {
-            // Reopen channel and try again
+        } catch (AMQPConnectionException) {
             $this->releaseChannel();
 
             return $this->purgeQueue($queueName);
         }
     }
 
-    /**
-     * Delete a queue.
-     *
-     * @return mixed
-     */
     public function deleteQueue(string $queueName)
     {
         try {
@@ -578,26 +449,19 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
 
             return $amqpQueue->delete();
         } catch (AMQPChannelException $exception) {
-            // If queue doesn't exist, just return
             if ($exception->getCode() === self::QUEUE_NOT_FOUND_CODE) {
                 return null;
             }
 
             throw $exception;
-        } catch (AMQPConnectionException $exception) {
-            // Reopen channel and try again
+        } catch (AMQPConnectionException) {
             $this->releaseChannel();
 
             return $this->deleteQueue($queueName);
         }
     }
 
-    /**
-     * Publish a message to the queue with retry logic.
-     *
-     * @throws JsonException
-     */
-    private function publishMessage(string $payload, string $queueName, int $attempts = 2): string
+    private function publishMessage(string $payload, string $queueName, int $attempts = 2, array $options = []): string
     {
         $correlationId = $this->createMessage($payload, $attempts);
         $messageAttributes = [
@@ -606,32 +470,33 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
             'content_type' => 'application/json',
         ];
 
+        if ($this->shouldPrioritizeDelayed()) {
+            $messageAttributes['priority'] = max(0, min($attempts, $this->getQueueMaxPriority()));
+        }
+
         try {
-            return $this->doPublish($payload, $queueName, $messageAttributes);
+            return $this->doPublish($payload, $queueName, $messageAttributes, $options);
         } catch (AMQPChannelException|AMQPConnectionException) {
-            // Reopen channel and try again
             $this->releaseChannel();
 
-            return $this->doPublish($payload, $queueName, $messageAttributes);
+            return $this->doPublish($payload, $queueName, $messageAttributes, $options);
         }
     }
 
-    /**
-     * Perform the actual message publishing.
-     */
-    private function doPublish(string $payload, string $queueName, array $messageAttributes): string
+    private function doPublish(string $payload, string $queueName, array $messageAttributes, array $options = []): string
     {
-        $amqpExchange = new AMQPExchange($this->getChannel());
-        $amqpExchange->setName('');
+        $exchangeName = $this->getExchange(Arr::get($options, 'exchange'));
+        $routingKey = $this->getRoutingKey($queueName);
 
-        // Enable publisher confirms if configured
+        $amqpExchange = new AMQPExchange($this->getChannel());
+        $amqpExchange->setName($exchangeName);
+
         if ($this->isPublisherConfirmsEnabled()) {
             $this->getPublisherConfirms()->enable();
         }
 
-        $amqpExchange->publish($payload, $queueName, AMQP_NOPARAM, $messageAttributes);
+        $amqpExchange->publish($payload, $routingKey, AMQP_NOPARAM, $messageAttributes);
 
-        // Wait for confirm if enabled
         if ($this->isPublisherConfirmsEnabled()) {
             $this->getPublisherConfirms()->waitForConfirms();
         }
@@ -639,9 +504,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $messageAttributes['correlation_id'];
     }
 
-    /**
-     * Declare a queue with advanced options (lazy, priority, DLX)
-     */
     public function declareAdvancedQueue(
         string $name,
         bool $durable = true,
@@ -653,17 +515,14 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
     ): void {
         $arguments = $additionalArguments;
 
-        // Lazy queue
         if ($lazy) {
             $arguments['x-queue-mode'] = 'lazy';
         }
 
-        // Priority queue
         if ($priority !== null && $priority > 0) {
             $arguments['x-max-priority'] = min($priority, 255);
         }
 
-        // Dead letter exchange
         if ($deadLetterConfig !== null) {
             $arguments['x-dead-letter-exchange'] = $deadLetterConfig['exchange'] ?? '';
             if (isset($deadLetterConfig['routing_key'])) {
@@ -677,9 +536,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         $this->declareQueue($name, $durable, $autoDelete, $arguments);
     }
 
-    /**
-     * Get the exchange manager
-     */
     public function getExchangeManager(): ExchangeManager
     {
         if ($this->exchangeManager === null) {
@@ -689,9 +545,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $this->exchangeManager;
     }
 
-    /**
-     * Get the exponential backoff instance
-     */
     public function getBackoff(): ExponentialBackoff
     {
         if ($this->backoff === null) {
@@ -707,9 +560,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $this->backoff;
     }
 
-    /**
-     * Get the publisher confirms instance
-     */
     public function getPublisherConfirms(): PublisherConfirms
     {
         if ($this->publisherConfirms === null) {
@@ -720,9 +570,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $this->publisherConfirms;
     }
 
-    /**
-     * Get the transaction manager
-     */
     public function getTransactionManager(): TransactionManager
     {
         if ($this->transactionManager === null) {
@@ -732,9 +579,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $this->transactionManager;
     }
 
-    /**
-     * Get the RPC client
-     */
     public function getRpcClient(): RpcClient
     {
         if ($this->rpcClient === null) {
@@ -745,9 +589,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $this->rpcClient;
     }
 
-    /**
-     * Publish to a specific exchange
-     */
     public function publishToExchange(
         string $exchangeName,
         string $payload,
@@ -762,7 +603,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
             'content_type' => 'application/json',
         ];
 
-        if (! empty($headers)) {
+        if ($headers !== []) {
             $attributes['headers'] = $headers;
         }
 
@@ -774,9 +615,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         );
     }
 
-    /**
-     * Make an RPC call
-     */
     public function rpcCall(string $queue, string $message, array $headers = []): string
     {
         if (! $this->isRpcEnabled()) {
@@ -786,9 +624,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $this->getRpcClient()->call($queue, $message, $headers);
     }
 
-    /**
-     * Execute a callback within a transaction
-     */
     public function transaction(callable $callback): mixed
     {
         if (! $this->isTransactionsEnabled()) {
@@ -798,33 +633,93 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         return $this->getTransactionManager()->transaction($callback);
     }
 
-    /**
-     * Check if publisher confirms are enabled
-     */
+    private function getQueueArguments(string $queueName): array
+    {
+        $queueConfig = config("queue.connections.rabbitmq.queues.{$queueName}", []);
+        $arguments = $queueConfig['arguments'] ?? [];
+
+        if (($queueConfig['lazy'] ?? config('queue.connections.rabbitmq.options.queue.lazy', false)) === true) {
+            $arguments['x-queue-mode'] = 'lazy';
+        }
+
+        $priority = $queueConfig['priority'] ?? ($this->shouldPrioritizeDelayed() ? $this->getQueueMaxPriority() : null);
+        if (is_numeric($priority) && (int) $priority > 0 && ! $this->isQuorumQueue($queueConfig)) {
+            $arguments['x-max-priority'] = min((int) $priority, 255);
+        }
+
+        if ($this->isQuorumQueue($queueConfig)) {
+            $arguments['x-queue-type'] = 'quorum';
+        }
+
+        if (config('queue.connections.rabbitmq.reroute_failed', false)) {
+            $arguments['x-dead-letter-exchange'] = config('queue.connections.rabbitmq.failed_exchange', '');
+            $arguments['x-dead-letter-routing-key'] = $this->getFailedRoutingKey($queueName);
+        }
+
+        return $arguments;
+    }
+
+    private function isQuorumQueue(array $queueConfig = []): bool
+    {
+        return (bool) ($queueConfig['quorum'] ?? config('queue.connections.rabbitmq.quorum', false));
+    }
+
+    private function getExchange(?string $exchange = null): string
+    {
+        return $exchange ?? config('queue.connections.rabbitmq.exchange', '');
+    }
+
+    private function getExchangeType(?string $type = null): string
+    {
+        $type = strtolower($type ?? config('queue.connections.rabbitmq.exchange_type', 'direct'));
+
+        return match ($type) {
+            'fanout' => AMQP_EX_TYPE_FANOUT,
+            'topic' => AMQP_EX_TYPE_TOPIC,
+            'headers' => AMQP_EX_TYPE_HEADERS,
+            default => AMQP_EX_TYPE_DIRECT,
+        };
+    }
+
+    private function getRoutingKey(string $queueName): string
+    {
+        $pattern = (string) config('queue.connections.rabbitmq.exchange_routing_key', '%s');
+
+        return ltrim(sprintf($pattern, $queueName), '.');
+    }
+
+    private function getFailedRoutingKey(string $queueName): string
+    {
+        $pattern = (string) config('queue.connections.rabbitmq.failed_routing_key', '%s.failed');
+
+        return ltrim(sprintf($pattern, $queueName), '.');
+    }
+
+    private function shouldPrioritizeDelayed(): bool
+    {
+        return (bool) config('queue.connections.rabbitmq.prioritize_delayed', false);
+    }
+
+    private function getQueueMaxPriority(): int
+    {
+        return max(1, (int) config('queue.connections.rabbitmq.queue_max_priority', 10));
+    }
+
     private function isPublisherConfirmsEnabled(): bool
     {
-        return config('queue.connections.rabbitmq.publisher_confirms.enabled', false);
+        return (bool) config('queue.connections.rabbitmq.publisher_confirms.enabled', false);
     }
 
-    /**
-     * Check if RPC is enabled
-     */
     private function isRpcEnabled(): bool
     {
-        return config('queue.connections.rabbitmq.rpc.enabled', false);
+        return (bool) config('queue.connections.rabbitmq.rpc.enabled', false);
     }
 
-    /**
-     * Check if transactions are enabled
-     */
     private function isTransactionsEnabled(): bool
     {
-        return config('queue.connections.rabbitmq.transactions.enabled', false);
+        return (bool) config('queue.connections.rabbitmq.transactions.enabled', false);
     }
 
-    /**
-     * Setup dead letter exchange for a queue
-     */
     public function setupDeadLetterExchange(
         string $queueName,
         ?string $dlxName = null,
@@ -847,9 +742,6 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         );
     }
 
-    /**
-     * Publish a delayed message
-     */
     public function publishDelayed(
         string $queue,
         string $payload,
@@ -859,17 +751,12 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
         $delayedConfig = config('queue.connections.rabbitmq.delayed_message', []);
 
         if ($delayedConfig['plugin_enabled'] ?? false) {
-            // Use RabbitMQ delayed message plugin
             return $this->publishDelayedWithPlugin($queue, $payload, $delay, $headers);
         }
 
-        // Use TTL-based delay (existing implementation)
         return $this->laterRaw($delay, $payload, $queue);
     }
 
-    /**
-     * Publish delayed message using RabbitMQ delayed message exchange plugin
-     */
     private function publishDelayedWithPlugin(
         string $queue,
         string $payload,
@@ -886,7 +773,7 @@ class RabbitQueue extends Queue implements RabbitQueueInterface
             'delivery_mode' => self::DELIVERY_MODE_PERSISTENT,
             'content_type' => 'application/json',
             'headers' => array_merge($headers, [
-                'x-delay' => $delay * 1000, // Convert to milliseconds
+                'x-delay' => $delay * 1000,
             ]),
         ];
 

--- a/tests/Unit/Connection/ConnectionConfigTest.php
+++ b/tests/Unit/Connection/ConnectionConfigTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelRabbitMQ\Tests\Unit\Connection;
+
+use iamfarhad\LaravelRabbitMQ\Connection\ConnectionFactory;
+use iamfarhad\LaravelRabbitMQ\Tests\UnitTestCase;
+use ReflectionClass;
+
+class ConnectionConfigTest extends UnitTestCase
+{
+    public function testBuildsLegacySingleHostConnectionConfigWithTimeouts(): void
+    {
+        $factory = new ConnectionFactory([
+            'hosts' => [
+                'host' => 'rabbitmq.local',
+                'port' => 5673,
+                'user' => 'app',
+                'password' => 'secret',
+                'vhost' => 'production',
+                'heartbeat' => 30,
+                'read_timeout' => 5.5,
+                'write_timeout' => 6,
+                'connect_timeout' => 3,
+            ],
+        ]);
+
+        $config = $this->invokeBuildConnectionConfig($factory);
+
+        $this->assertSame('rabbitmq.local', $config['host']);
+        $this->assertSame(5673, $config['port']);
+        $this->assertSame('app', $config['login']);
+        $this->assertSame('secret', $config['password']);
+        $this->assertSame('production', $config['vhost']);
+        $this->assertSame(30, $config['heartbeat']);
+        $this->assertSame(5.5, $config['read_timeout']);
+        $this->assertSame(6, $config['write_timeout']);
+        $this->assertSame(3, $config['connect_timeout']);
+    }
+
+    public function testBuildsConnectionConfigFromMultiHostList(): void
+    {
+        $factory = new ConnectionFactory([
+            'hosts' => [
+                [
+                    'host' => 'rabbitmq-a.local',
+                    'port' => 5672,
+                    'user' => 'app-a',
+                    'password' => 'secret-a',
+                    'vhost' => '/',
+                ],
+            ],
+            'options' => [
+                'read_timeout' => 10,
+                'write_timeout' => 11,
+                'connect_timeout' => 12,
+            ],
+        ]);
+
+        $config = $this->invokeBuildConnectionConfig($factory);
+
+        $this->assertSame('rabbitmq-a.local', $config['host']);
+        $this->assertSame(5672, $config['port']);
+        $this->assertSame('app-a', $config['login']);
+        $this->assertSame('secret-a', $config['password']);
+        $this->assertSame('/', $config['vhost']);
+        $this->assertSame(10, $config['read_timeout']);
+        $this->assertSame(11, $config['write_timeout']);
+        $this->assertSame(12, $config['connect_timeout']);
+    }
+
+    public function testIgnoresNonPositiveOptionalConnectionValues(): void
+    {
+        $factory = new ConnectionFactory([
+            'hosts' => [
+                'heartbeat' => 0,
+                'read_timeout' => -1,
+                'write_timeout' => 0,
+                'connect_timeout' => null,
+            ],
+        ]);
+
+        $config = $this->invokeBuildConnectionConfig($factory);
+
+        $this->assertArrayNotHasKey('heartbeat', $config);
+        $this->assertArrayNotHasKey('read_timeout', $config);
+        $this->assertArrayNotHasKey('write_timeout', $config);
+        $this->assertArrayNotHasKey('connect_timeout', $config);
+    }
+
+    private function invokeBuildConnectionConfig(ConnectionFactory $factory): array
+    {
+        $reflection = new ReflectionClass($factory);
+        $method = $reflection->getMethod('buildConnectionConfig');
+        $method->setAccessible(true);
+
+        return $method->invoke($factory);
+    }
+}

--- a/tests/Unit/RabbitQueueConfigurationTest.php
+++ b/tests/Unit/RabbitQueueConfigurationTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use iamfarhad\LaravelRabbitMQ\Connection\PoolManager;
+use iamfarhad\LaravelRabbitMQ\RabbitQueue;
+use iamfarhad\LaravelRabbitMQ\Tests\TestCase;
+use Mockery;
+
+class RabbitQueueConfigurationTest extends TestCase
+{
+    public function testBuildsQueueArgumentsForLazyPriorityAndFailedReroute(): void
+    {
+        config([
+            'queue.connections.rabbitmq.prioritize_delayed' => true,
+            'queue.connections.rabbitmq.queue_max_priority' => 8,
+            'queue.connections.rabbitmq.reroute_failed' => true,
+            'queue.connections.rabbitmq.failed_exchange' => 'failed.jobs',
+            'queue.connections.rabbitmq.failed_routing_key' => '%s.failed',
+            'queue.connections.rabbitmq.queues.default.lazy' => true,
+        ]);
+
+        $queue = $this->makeQueue();
+        $arguments = $this->invokePrivate($queue, 'getQueueArguments', ['default']);
+
+        $this->assertSame('lazy', $arguments['x-queue-mode']);
+        $this->assertSame(8, $arguments['x-max-priority']);
+        $this->assertSame('failed.jobs', $arguments['x-dead-letter-exchange']);
+        $this->assertSame('default.failed', $arguments['x-dead-letter-routing-key']);
+    }
+
+    public function testBuildsQuorumQueueArgumentsWithoutPriority(): void
+    {
+        config([
+            'queue.connections.rabbitmq.prioritize_delayed' => true,
+            'queue.connections.rabbitmq.queue_max_priority' => 8,
+            'queue.connections.rabbitmq.quorum' => true,
+        ]);
+
+        $queue = $this->makeQueue();
+        $arguments = $this->invokePrivate($queue, 'getQueueArguments', ['default']);
+
+        $this->assertSame('quorum', $arguments['x-queue-type']);
+        $this->assertArrayNotHasKey('x-max-priority', $arguments);
+    }
+
+    public function testResolvesExchangeTypeRoutingKeyAndFailedRoutingKey(): void
+    {
+        config([
+            'queue.connections.rabbitmq.exchange' => 'jobs',
+            'queue.connections.rabbitmq.exchange_type' => 'topic',
+            'queue.connections.rabbitmq.exchange_routing_key' => 'jobs.%s',
+            'queue.connections.rabbitmq.failed_routing_key' => 'failed.%s',
+        ]);
+
+        $queue = $this->makeQueue();
+
+        $this->assertSame('jobs', $this->invokePrivate($queue, 'getExchange'));
+        $this->assertSame(AMQP_EX_TYPE_TOPIC, $this->invokePrivate($queue, 'getExchangeType'));
+        $this->assertSame('jobs.default', $this->invokePrivate($queue, 'getRoutingKey', ['default']));
+        $this->assertSame('failed.default', $this->invokePrivate($queue, 'getFailedRoutingKey', ['default']));
+    }
+
+    private function makeQueue(): RabbitQueue
+    {
+        return new RabbitQueue(Mockery::mock(PoolManager::class), 'default');
+    }
+
+    private function invokePrivate(RabbitQueue $queue, string $method, array $arguments = []): mixed
+    {
+        $reflection = new ReflectionClass($queue);
+        $method = $reflection->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($queue, $arguments);
+    }
+}


### PR DESCRIPTION
## Summary
- Keep connection retry backoff scoped to a single connection attempt, so one failure does not permanently increase delay for future connections
- Make `--consumer-tag` accept a value instead of being parsed as a boolean flag
- Release cached AMQP channels after passive queue-declare 404s, because RabbitMQ closes channels on passive declaration misses
- Make `ext-pcntl` optional and only suggested; it is required at runtime only for `rabbitmq:consume --num-processes > 1`
- Add backward-compatible multi-host configuration support and read/write/connect timeout mapping
- Expand config defaults for exchange/routing-key publishing, delayed priority, quorum queues, failed-message rerouting, Horizon worker mode, Octane reset behavior, and consume mode
- Wire normal queue publishing to configurable exchange/routing-key behavior while preserving the default exchange behavior
- Add queue arguments for lazy queues, quorum queues, delayed-message priority, and failed rerouting
- Add optional Laravel Horizon support via `RABBITMQ_WORKER=horizon` when Horizon is installed
- Add Horizon queue events for pending/pushed/reserved/deleted jobs and failed-job forwarding
- Add optional Octane pool reset hook via `RABBITMQ_OCTANE_RESET_ON_REQUEST=true` when Octane is installed
- Add opt-in high-performance `basic_consume` mode via `RABBITMQ_CONSUME_MODE=consume` or `rabbitmq:consume --consume-mode=consume`
- Add queue admin commands: `rabbitmq:queue-declare`, `rabbitmq:queue-purge`, `rabbitmq:queue-delete`
- Add exchange admin command: `rabbitmq:exchange-declare`
- Add unit coverage for connection config and queue routing/argument configuration
- Run Pint and PHPStan in CI before PHPUnit

## Comparison-driven additions
This PR incorporates the high-value ideas from `vyuldashev/laravel-queue-rabbitmq` without switching away from this package's `ext-amqp` + pooling architecture:
- optional pcntl instead of hard requirement
- multi-host config
- timeout config
- exchange/routing-key publishing
- failed-message rerouting config
- quorum queue support
- operational admin commands
- Horizon integration hooks
- Octane cleanup hook
- optional basic_consume worker mode
- stronger CI checks

## Compatibility notes
- Defaults remain backward compatible: polling remains the default consume mode, the default exchange remains `''`, and Horizon/Octane integrations are only active when configured and installed.
- Horizon and Octane classes are guarded with `class_exists()` so the package does not require those packages.

## Testing
- Added unit tests for connection config normalization and queue config/routing helpers.
- CI now runs `composer format-test`, `composer analyse`, and the existing PHPUnit suites.
- GitHub Actions are running on the branch; final pass/fail should be checked before merge.