### PR TITLE
Remove static analysis from GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,9 +83,6 @@ jobs:
       - name: Run formatting check
         run: composer format-test
 
-      - name: Run static analysis
-        run: composer analyse
-
       - name: Clear PHPUnit cache
         run: |
           rm -rf .phpunit.cache


### PR DESCRIPTION
## Summary
- Remove the `composer analyse` / PHPStan step from `.github/workflows/tests.yml`
- Keep formatting checks and PHPUnit/RabbitMQ test runs in the matrix

## Testing
- Workflow-only change; GitHub Actions will validate formatting and tests on this PR.