### PR TITLE
Add support, security, compatibility docs and expand CI matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug report
+description: Report a reproducible bug in Laravel RabbitMQ
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include a minimal reproduction whenever possible.
+  - type: input
+    id: package-version
+    attributes:
+      label: Package version
+      description: Composer version or commit SHA.
+      placeholder: "v1.2.3 or 6d88645"
+    validations:
+      required: true
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP version
+      placeholder: "8.3.12"
+    validations:
+      required: true
+  - type: input
+    id: laravel-version
+    attributes:
+      label: Laravel version
+      placeholder: "11.34.0"
+    validations:
+      required: true
+  - type: input
+    id: rabbitmq-version
+    attributes:
+      label: RabbitMQ version
+      placeholder: "3.13.7 or 4.0.4"
+    validations:
+      required: true
+  - type: input
+    id: amqp-version
+    attributes:
+      label: ext-amqp version
+      placeholder: "2.1.2"
+    validations:
+      required: true
+  - type: dropdown
+    id: worker
+    attributes:
+      label: Worker command
+      options:
+        - php artisan queue:work rabbitmq
+        - php artisan rabbitmq:consume
+        - Laravel Horizon
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: consume-mode
+    attributes:
+      label: Consume mode
+      options:
+        - poll
+        - consume
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Include code, config, worker command, and queue topology. Remove secrets.
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or stack trace
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/iamfarhad/LaravelRabbitMQ/security/advisories/new
+    about: Please report vulnerabilities privately through GitHub Security Advisories.
+  - name: Support policy
+    url: https://github.com/iamfarhad/LaravelRabbitMQ/blob/master/SUPPORT.md
+    about: Check supported PHP, Laravel, and RabbitMQ versions before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest an improvement for Laravel RabbitMQ
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please explain the use case before the implementation details.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility impact
+      description: Mention affected PHP, Laravel, RabbitMQ, or ext-amqp versions if known.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+- 
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / maintenance
+- [ ] Breaking change
+
+## Checklist
+
+- [ ] I have read `CONTRIBUTING.md`.
+- [ ] I added or updated tests where relevant.
+- [ ] I updated documentation where relevant.
+- [ ] `composer format-test` passes.
+- [ ] `composer analyse` passes.
+- [ ] `composer test` passes.
+
+## Runtime matrix checked
+
+- PHP version(s):
+- Laravel version(s):
+- RabbitMQ version(s):
+
+## Notes for reviewers
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,7 @@ jobs:
           fi
 
       - name: Run formatting check
+        if: matrix.dependency-version != 'prefer-lowest'
         run: composer format-test
 
       - name: Clear PHPUnit cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,33 +23,79 @@ jobs:
           - php: '8.2'
             laravel: '11.*'
             testbench: '9.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
           - php: '8.2'
             laravel: '12.*'
             testbench: '10.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
           - php: '8.3'
             laravel: '11.*'
             testbench: '9.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
           - php: '8.3'
             laravel: '12.*'
             testbench: '10.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
           - php: '8.3'
             laravel: '13.*'
             testbench: '11.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
           - php: '8.4'
             laravel: '11.*'
             testbench: '9.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
           - php: '8.4'
             laravel: '12.*'
             testbench: '10.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
           - php: '8.4'
             laravel: '13.*'
             testbench: '11.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
+          - php: '8.5'
+            laravel: '11.*'
+            testbench: '9.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
+          - php: '8.5'
+            laravel: '12.*'
+            testbench: '10.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
+          - php: '8.5'
+            laravel: '13.*'
+            testbench: '11.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
+          - php: '8.2'
+            laravel: '11.*'
+            testbench: '9.*'
+            dependency-version: prefer-lowest
+            rabbitmq: '3.13-management'
+          - php: '8.5'
+            laravel: '13.*'
+            testbench: '11.*'
+            dependency-version: prefer-lowest
+            rabbitmq: '4-management'
+          - php: '8.4'
+            laravel: '12.*'
+            testbench: '10.*'
+            dependency-version: prefer-stable
+            rabbitmq: '4-management'
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }} - RabbitMQ ${{ matrix.rabbitmq }}
 
     services:
       rabbitmq:
-        image: rabbitmq:3-management
+        image: rabbitmq:${{ matrix.rabbitmq }}
         env:
           RABBITMQ_DEFAULT_USER: laravel
           RABBITMQ_DEFAULT_PASS: secret
@@ -78,7 +124,11 @@ jobs:
         run: |
           composer require "illuminate/console:${{ matrix.laravel }}" "illuminate/database:${{ matrix.laravel }}" "illuminate/filesystem:${{ matrix.laravel }}" --no-update
           composer require "orchestra/testbench:${{ matrix.testbench }}" --dev --no-update
-          composer update --prefer-dist --no-progress --with-all-dependencies
+          if [ "${{ matrix.dependency-version }}" = "prefer-lowest" ]; then
+            composer update --prefer-lowest --prefer-stable --prefer-dist --no-progress --with-all-dependencies
+          else
+            composer update --prefer-stable --prefer-dist --no-progress --with-all-dependencies
+          fi
 
       - name: Run formatting check
         run: composer format-test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,11 @@ jobs:
       matrix:
         include:
           - php: '8.2'
+            laravel: '10.*'
+            testbench: '8.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
+          - php: '8.2'
             laravel: '11.*'
             testbench: '9.*'
             dependency-version: prefer-stable
@@ -31,6 +36,11 @@ jobs:
             dependency-version: prefer-stable
             rabbitmq: '3.13-management'
           - php: '8.3'
+            laravel: '10.*'
+            testbench: '8.*'
+            dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
+          - php: '8.3'
             laravel: '11.*'
             testbench: '9.*'
             dependency-version: prefer-stable
@@ -74,6 +84,11 @@ jobs:
             laravel: '13.*'
             testbench: '11.*'
             dependency-version: prefer-stable
+            rabbitmq: '3.13-management'
+          - php: '8.2'
+            laravel: '10.*'
+            testbench: '8.*'
+            dependency-version: prefer-lowest
             rabbitmq: '3.13-management'
           - php: '8.2'
             laravel: '11.*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+Thanks for contributing to Laravel RabbitMQ.
+
+## Development requirements
+
+- PHP 8.2 or higher.
+- Composer 2.
+- `ext-amqp` enabled.
+- RabbitMQ 3.13 or 4.x for integration testing.
+- `ext-pcntl` when testing multi-process consumers.
+
+## Setup
+
+```bash
+git clone https://github.com/iamfarhad/LaravelRabbitMQ.git
+cd LaravelRabbitMQ
+composer install
+```
+
+Start RabbitMQ locally:
+
+```bash
+docker run -d --name laravel-rabbitmq \
+  -p 5672:5672 \
+  -p 15672:15672 \
+  -e RABBITMQ_DEFAULT_USER=laravel \
+  -e RABBITMQ_DEFAULT_PASS=secret \
+  -e RABBITMQ_DEFAULT_VHOST=b2b-field \
+  rabbitmq:3.13-management
+```
+
+## Quality checks
+
+Run these before opening a pull request:
+
+```bash
+composer format-test
+composer analyse
+composer test
+```
+
+The full CI matrix also runs dependency-boundary jobs with Composer `--prefer-lowest` and `--prefer-stable`, multiple PHP/Laravel combinations, and RabbitMQ 3.13 / 4.x service containers.
+
+## Pull request guidelines
+
+- Keep pull requests focused and small enough to review.
+- Include tests for behavior changes.
+- Update README or docs when configuration, commands, or runtime support changes.
+- Avoid breaking public APIs unless the pull request also includes migration notes.
+- Do not include secrets, real credentials, or private broker topology in issues or tests.
+
+## Coding standards
+
+This package uses Laravel Pint and PHPStan.
+
+Prefer clear, typed code and small methods. When changing worker, acknowledgement, retry, or connection-pool behavior, include tests covering failure paths.
+
+## Documentation style
+
+- Use fenced code blocks with language hints.
+- Keep configuration examples secret-free.
+- Mention version constraints when behavior depends on PHP, Laravel, RabbitMQ, or `ext-amqp`.
+- Link to `SUPPORT.md`, `UPGRADE.md`, and `MIGRATION.md` when applicable.
+
+## Security reports
+
+Do not open public issues for vulnerabilities. Follow [SECURITY.md](SECURITY.md).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,109 @@
+# Migration Guide
+
+This guide helps applications migrate to `iamfarhad/laravel-rabbitmq` from Laravel's built-in queue drivers or other RabbitMQ queue packages.
+
+## Migrate from database, Redis, SQS, or sync queues
+
+1. Install the package and AMQP extension.
+
+```bash
+composer require iamfarhad/laravel-rabbitmq
+pecl install amqp
+```
+
+2. Publish configuration.
+
+```bash
+php artisan vendor:publish \
+  --provider="iamfarhad\\LaravelRabbitMQ\\LaravelRabbitQueueServiceProvider" \
+  --tag="config"
+```
+
+3. Configure the queue connection.
+
+```env
+QUEUE_CONNECTION=rabbitmq
+RABBITMQ_HOST=127.0.0.1
+RABBITMQ_PORT=5672
+RABBITMQ_USER=guest
+RABBITMQ_PASSWORD=guest
+RABBITMQ_VHOST=/
+RABBITMQ_QUEUE=default
+```
+
+4. Run a smoke test.
+
+```bash
+php artisan queue:work rabbitmq --queue=default --once
+```
+
+5. Move workers gradually by queue name. Keep old workers running until old queues are drained.
+
+## Migrate from `vladimir-yuldashev/laravel-queue-rabbitmq`
+
+The package intentionally keeps Laravel Queue semantics familiar, but it is not a drop-in replacement for every internal config key or extension point.
+
+### Composer package
+
+```bash
+composer remove vladimir-yuldashev/laravel-queue-rabbitmq
+composer require iamfarhad/laravel-rabbitmq
+```
+
+### Connection name
+
+Use the `rabbitmq` connection name:
+
+```env
+QUEUE_CONNECTION=rabbitmq
+```
+
+### Worker command
+
+You can continue using Laravel's worker:
+
+```bash
+php artisan queue:work rabbitmq --queue=default
+```
+
+Or use the package consumer command for RabbitMQ-specific worker options:
+
+```bash
+php artisan rabbitmq:consume --queue=default --consume-mode=poll
+php artisan rabbitmq:consume --queue=default --consume-mode=consume
+```
+
+### Configuration mapping
+
+| Existing concept | New setting |
+| --- | --- |
+| Host, port, user, password, vhost | `RABBITMQ_HOST`, `RABBITMQ_PORT`, `RABBITMQ_USER`, `RABBITMQ_PASSWORD`, `RABBITMQ_VHOST` |
+| Queue name | `RABBITMQ_QUEUE` |
+| Exchange name | `RABBITMQ_EXCHANGE` |
+| Exchange type | `RABBITMQ_EXCHANGE_TYPE` |
+| Routing key | `RABBITMQ_EXCHANGE_ROUTING_KEY` |
+| SSL/TLS options | `RABBITMQ_SECURE` and `options.ssl_options` in config |
+| Dead lettering | `RABBITMQ_REROUTE_FAILED`, `RABBITMQ_FAILED_EXCHANGE`, `RABBITMQ_FAILED_ROUTING_KEY` |
+| Quorum queue | `RABBITMQ_QUEUE_QUORUM` or per-queue `quorum` config |
+| Lazy queue | `RABBITMQ_QUEUE_LAZY` or per-queue `lazy` config |
+| Priority queue | `RABBITMQ_QUEUE_MAX_PRIORITY` or per-queue `priority` config |
+
+### Important behavior checks
+
+- This package uses native `ext-amqp`; make sure the extension is installed in every runtime and CI image.
+- The default consume mode is `poll`, using `basic_get`, for Laravel worker lifecycle compatibility.
+- `consume` mode uses push-style `basic_consume` and is best with one queue per worker process.
+- Quorum queues and priority queues are mutually exclusive in RabbitMQ.
+- Restart all workers after changing queue config.
+
+## Migration checklist
+
+- [ ] Confirm PHP, Laravel, RabbitMQ, and `ext-amqp` versions are supported.
+- [ ] Publish and review `config/rabbitmq.php`.
+- [ ] Configure connection credentials without committing secrets.
+- [ ] Declare or verify exchanges, queues, and bindings.
+- [ ] Run one job through `queue:work rabbitmq`.
+- [ ] Run one job through `rabbitmq:consume` if you plan to use it.
+- [ ] Verify failed-job behavior and dead-letter routing.
+- [ ] Restart all workers.
+- [ ] Monitor ready/unacked/dead-letter queue counts during rollout.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@
 [![License](https://poser.pugx.org/iamfarhad/laravel-rabbitmq/license?format=flat-square)](https://packagist.org/packages/iamfarhad/laravel-rabbitmq)
 [![Tests](https://github.com/iamfarhad/LaravelRabbitMQ/actions/workflows/tests.yml/badge.svg)](https://github.com/iamfarhad/LaravelRabbitMQ/actions/workflows/tests.yml)
 
-A production-focused RabbitMQ queue driver for Laravel with native Laravel Queue integration, connection/channel pooling, configurable RabbitMQ topology, Horizon hooks, Octane-safe pool reset support, and an optional high-performance `basic_consume` worker mode.
+A production-focused RabbitMQ queue driver for Laravel with native Laravel Queue integration, connection/channel pooling, configurable RabbitMQ topology, Horizon hooks, Octane-safe pool reset support, and optional high-performance `basic_consume` worker mode.
+
+## Documentation
+
+- [Support policy and compatibility matrix](SUPPORT.md)
+- [Security policy](SECURITY.md)
+- [Contributing guide](CONTRIBUTING.md)
+- [Upgrade guide](UPGRADE.md)
+- [Migration guide](MIGRATION.md)
+- [Comparison with `vladimir-yuldashev/laravel-queue-rabbitmq`](docs/comparison-vladimir-yuldashev.md)
 
 ## Features
 
@@ -13,7 +22,6 @@ A production-focused RabbitMQ queue driver for Laravel with native Laravel Queue
 - Native `ext-amqp` implementation for high-performance AMQP operations.
 - Connection and channel pooling with health checks and retry backoff.
 - Backward-compatible single-host config and production multi-host config.
-- Connection timeout support: read, write, and connect timeout.
 - Configurable exchange, exchange type, and routing-key publishing for normal Laravel jobs.
 - Lazy queues, priority queues, quorum queues, delayed messages, dead-letter routing, and failed-message rerouting.
 - Publisher confirms, transactions, RPC helpers, exchange helpers, and queue management helpers.
@@ -26,9 +34,11 @@ A production-focused RabbitMQ queue driver for Laravel with native Laravel Queue
 
 - PHP 8.2 or higher.
 - Laravel 11.x, 12.x, or 13.x.
-- RabbitMQ 3.8 or higher.
+- RabbitMQ 3.13 or 4.x for the primary supported/tested matrix; RabbitMQ 3.8-3.12 is best effort.
 - `ext-amqp` PHP extension.
 - `ext-pcntl` is optional and only required when running `rabbitmq:consume --num-processes` with a value greater than `1`.
+
+See [SUPPORT.md](SUPPORT.md) for the full Laravel/PHP/RabbitMQ support matrix.
 
 ## Installation
 
@@ -54,7 +64,7 @@ Publish the config:
 
 ```bash
 php artisan vendor:publish \
-  --provider="iamfarhad\LaravelRabbitMQ\LaravelRabbitQueueServiceProvider" \
+  --provider="iamfarhad\\LaravelRabbitMQ\\LaravelRabbitQueueServiceProvider" \
   --tag="config"
 ```
 
@@ -82,7 +92,7 @@ Start RabbitMQ locally:
 docker run -d --name rabbitmq \
   -p 5672:5672 \
   -p 15672:15672 \
-  rabbitmq:3-management
+  rabbitmq:3.13-management
 ```
 
 Dispatch Laravel jobs normally:
@@ -131,7 +141,7 @@ The package merges `config/rabbitmq.php` into `queue.connections.rabbitmq`, so y
 
 ### Multi-host configuration
 
-Use a list of hosts for basic high-availability. The connector randomly selects a host for each new connection attempt.
+Use a list of hosts for basic high availability. The connector randomly selects a host for each new connection attempt.
 
 ```php
 'hosts' => [
@@ -176,7 +186,7 @@ RABBITMQ_HEALTH_CHECK_INTERVAL=30
 
 ## Publishing topology
 
-By default the package preserves RabbitMQ's default exchange behavior and routes jobs directly to the queue name. For production routing, configure an exchange and routing-key pattern:
+By default, the package preserves RabbitMQ's default exchange behavior and routes jobs directly to the queue name. For production routing, configure an exchange and routing-key pattern:
 
 ```env
 RABBITMQ_EXCHANGE=jobs
@@ -301,11 +311,11 @@ RABBITMQ_WORKER=horizon
 
 When Horizon is installed and `RABBITMQ_WORKER=horizon` is set, the package uses an optional Horizon-aware queue class and dispatches Horizon events for:
 
-- pending jobs
-- pushed jobs
-- reserved jobs
-- deleted jobs
-- failed jobs
+- Pending jobs
+- Pushed jobs
+- Reserved jobs
+- Deleted jobs
+- Failed jobs
 
 The package does not require Horizon. All Horizon references are guarded and inactive when Horizon is not installed.
 
@@ -496,7 +506,13 @@ composer analyse
 composer test
 ```
 
-The GitHub Actions test workflow runs Pint, PHPStan, and PHPUnit across the supported Laravel/PHP matrix with a RabbitMQ service container.
+The GitHub Actions test workflow runs Pint, PHPStan, and PHPUnit across the supported Laravel/PHP matrix with RabbitMQ 3.13 and 4.x service containers. It also includes Composer `prefer-lowest` and `prefer-stable` dependency jobs.
+
+## Upgrading and migrating
+
+- Read [UPGRADE.md](UPGRADE.md) before changing package, Laravel, PHP, or RabbitMQ versions.
+- Read [MIGRATION.md](MIGRATION.md) when moving from another Laravel queue driver or from `vladimir-yuldashev/laravel-queue-rabbitmq`.
+- Read the [comparison page](docs/comparison-vladimir-yuldashev.md) when choosing between RabbitMQ queue packages.
 
 ## Troubleshooting
 
@@ -530,6 +546,14 @@ RABBITMQ_WORKER=horizon
 ```
 
 Then restart your workers.
+
+## Security
+
+Please report vulnerabilities privately. See [SECURITY.md](SECURITY.md).
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+Thank you for helping keep Laravel RabbitMQ secure.
+
+## Supported versions
+
+Security fixes are provided for the currently supported package versions and the supported runtime matrix documented in [SUPPORT.md](SUPPORT.md).
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities in public GitHub issues.
+
+Report vulnerabilities through GitHub Security Advisories when available, or email the maintainer listed in `composer.json` with the subject:
+
+```text
+Security report for iamfarhad/laravel-rabbitmq
+```
+
+Include as much detail as possible:
+
+- Affected package version or commit SHA.
+- PHP, Laravel, RabbitMQ, and `ext-amqp` versions.
+- Configuration needed to reproduce the issue, with credentials removed.
+- A proof of concept or clear reproduction steps.
+- Potential impact and whether the issue is being actively exploited.
+
+## Response expectations
+
+The maintainer will triage valid reports as quickly as possible. Confirmed vulnerabilities will be fixed privately when practical, then disclosed with a release note or advisory after a patch is available.
+
+## Scope
+
+In scope:
+
+- Package code that can compromise confidentiality, integrity, or availability of Laravel applications using this driver.
+- Unsafe handling of RabbitMQ connection settings, queue payloads, acknowledgements, retries, or failed jobs.
+- Dependency or CI issues that materially affect package consumers.
+
+Out of scope:
+
+- Vulnerabilities in RabbitMQ itself, PHP, Laravel, `ext-amqp`, or infrastructure outside this repository.
+- Reports that require access to secrets, credentials, or systems not controlled by the reporter.
+- Denial-of-service reports without a realistic package-level mitigation.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,17 +7,20 @@ This package follows the supported PHP and Laravel versions declared in `compose
 | Component | Supported | CI coverage | Notes |
 | --- | --- | --- | --- |
 | PHP | 8.2, 8.3, 8.4, 8.5 | Yes | PHP 8.5 is included in the test matrix to catch upcoming/runtime compatibility issues early. |
-| Laravel | 11.x, 12.x, 13.x | Yes | Support is provided through `illuminate/queue` and `illuminate/support`. |
+| Laravel | 10.x, 11.x, 12.x, 13.x | Yes | Support is provided through `illuminate/queue` and `illuminate/support`. |
 | RabbitMQ | 3.13, 4.x | Yes | These are the actively tested broker lines. |
 | RabbitMQ | 3.8 - 3.12 | Best effort | Expected to work for common AMQP 0-9-1 queue usage, but not part of the primary CI matrix. |
 | RabbitMQ | < 3.8 | No | Upgrade RabbitMQ before opening compatibility bugs. |
-| PHP extension | `ext-amqp` | Yes | Required. The package uses the native AMQP extension, not `php-amqplib`. |
+| PHP extension | `ext-amqp` | Yes | Required. The package uses the native AMQP extension. |
 | Optional extension | `ext-pcntl` | Partial | Required only for `rabbitmq:consume --num-processes` values greater than `1`. |
+| Laravel Horizon | Compatible | Optional | Enable with `RABBITMQ_WORKER=horizon`; Horizon is not required. |
+| Laravel Octane | Compatible | Optional | Enable per-request pool cleanup with `RABBITMQ_OCTANE_RESET_ON_REQUEST=true`. |
 
 ## Laravel / PHP support matrix
 
 | Laravel | PHP 8.2 | PHP 8.3 | PHP 8.4 | PHP 8.5 | Testbench |
 | --- | --- | --- | --- | --- | --- |
+| 10.x | Supported | Supported | Not tested | Not tested | 8.x |
 | 11.x | Supported | Supported | Supported | Supported | 9.x |
 | 12.x | Supported | Supported | Supported | Supported | 10.x |
 | 13.x | Not tested | Supported | Supported | Supported | 11.x |
@@ -30,6 +33,14 @@ This package follows the supported PHP and Laravel versions declared in `compose
 | 4.x | Supported | `rabbitmq:4-management` |
 | 3.8.x - 3.12.x | Best effort | Not tested on every pull request |
 | Older than 3.8 | Unsupported | Not tested |
+
+## Transport support
+
+| Transport | Status | Notes |
+| --- | --- | --- |
+| `tcp` | Supported | Default AMQP connection over TCP. |
+| `ssl` | Supported | Native `ext-amqp` TLS/SSL connection options. |
+| `tls` | Supported | Alias-style transport option for TLS deployments. |
 
 ## What gets fixed
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,53 @@
+# Support Policy
+
+This package follows the supported PHP and Laravel versions declared in `composer.json` and verified by GitHub Actions.
+
+## Supported versions
+
+| Component | Supported | CI coverage | Notes |
+| --- | --- | --- | --- |
+| PHP | 8.2, 8.3, 8.4, 8.5 | Yes | PHP 8.5 is included in the test matrix to catch upcoming/runtime compatibility issues early. |
+| Laravel | 11.x, 12.x, 13.x | Yes | Support is provided through `illuminate/queue` and `illuminate/support`. |
+| RabbitMQ | 3.13, 4.x | Yes | These are the actively tested broker lines. |
+| RabbitMQ | 3.8 - 3.12 | Best effort | Expected to work for common AMQP 0-9-1 queue usage, but not part of the primary CI matrix. |
+| RabbitMQ | < 3.8 | No | Upgrade RabbitMQ before opening compatibility bugs. |
+| PHP extension | `ext-amqp` | Yes | Required. The package uses the native AMQP extension, not `php-amqplib`. |
+| Optional extension | `ext-pcntl` | Partial | Required only for `rabbitmq:consume --num-processes` values greater than `1`. |
+
+## Laravel / PHP support matrix
+
+| Laravel | PHP 8.2 | PHP 8.3 | PHP 8.4 | PHP 8.5 | Testbench |
+| --- | --- | --- | --- | --- | --- |
+| 11.x | Supported | Supported | Supported | Supported | 9.x |
+| 12.x | Supported | Supported | Supported | Supported | 10.x |
+| 13.x | Not tested | Supported | Supported | Supported | 11.x |
+
+## RabbitMQ support matrix
+
+| RabbitMQ | Status | CI image |
+| --- | --- | --- |
+| 3.13.x | Supported | `rabbitmq:3.13-management` |
+| 4.x | Supported | `rabbitmq:4-management` |
+| 3.8.x - 3.12.x | Best effort | Not tested on every pull request |
+| Older than 3.8 | Unsupported | Not tested |
+
+## What gets fixed
+
+Security fixes are prioritized for all supported versions when a safe fix is available.
+
+Bug fixes are prioritized when they affect a supported Laravel/PHP/RabbitMQ combination, include a reproducible example, and do not require breaking API changes.
+
+New features target the latest supported Laravel and RabbitMQ combinations first. Older supported combinations may receive the feature when the implementation remains compatible.
+
+## Opening support requests
+
+Before opening an issue, please include:
+
+- Package version or commit SHA.
+- PHP, Laravel, RabbitMQ, and `ext-amqp` versions.
+- Whether the worker is `queue:work` or `rabbitmq:consume`.
+- Whether `RABBITMQ_CONSUME_MODE` is `poll` or `consume`.
+- A minimal reproduction or failing test.
+- Redacted RabbitMQ connection/topology configuration.
+
+Use GitHub Discussions or a question issue for usage questions. Use the security policy for vulnerabilities.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,107 @@
+# Upgrade Guide
+
+This guide highlights upgrade checks for Laravel RabbitMQ users.
+
+## Before upgrading
+
+1. Read the release notes and changelog for the target version.
+2. Confirm your runtime is supported in [SUPPORT.md](SUPPORT.md).
+3. Back up production queue topology and worker configuration.
+4. Test with a staging RabbitMQ broker before deploying to production.
+5. Restart all long-running queue workers after deployment.
+
+## General upgrade steps
+
+```bash
+composer require iamfarhad/laravel-rabbitmq:^<target-version> --with-all-dependencies
+php artisan vendor:publish \
+  --provider="iamfarhad\\LaravelRabbitMQ\\LaravelRabbitQueueServiceProvider" \
+  --tag="config" \
+  --force
+```
+
+Review the published `config/rabbitmq.php` diff before committing it. Do not overwrite custom connection, exchange, queue, dead-letter, or SSL settings without checking them.
+
+Run your test suite and queue smoke tests:
+
+```bash
+composer test
+php artisan queue:work rabbitmq --queue=default --once
+php artisan rabbitmq:consume --queue=default --num-processes=1 --once
+```
+
+If your version of `rabbitmq:consume` does not support `--once`, run it in a controlled environment and stop it after a successful job.
+
+## Upgrading PHP or Laravel
+
+- PHP 8.2, 8.3, 8.4, and 8.5 are supported.
+- Laravel 11.x, 12.x, and 13.x are supported.
+- Make sure `ext-amqp` is available for the new PHP runtime.
+- Rebuild containers or server images after changing PHP versions.
+
+Check the installed extension:
+
+```bash
+php -m | grep amqp
+php --ri amqp
+```
+
+## Upgrading RabbitMQ
+
+RabbitMQ 3.13 and 4.x are the primary supported broker lines.
+
+Before upgrading RabbitMQ:
+
+- Confirm queue types used by your app: classic, quorum, lazy, priority, delayed-message plugin.
+- Confirm delayed-message plugin compatibility if you use `RABBITMQ_DELAYED_PLUGIN_ENABLED=true`.
+- Drain or pause non-critical workers during broker upgrades when possible.
+- Verify vhosts, users, policies, exchanges, queues, bindings, and permissions after upgrade.
+
+## Configuration checks
+
+Review these settings during every major upgrade:
+
+```env
+QUEUE_CONNECTION=rabbitmq
+RABBITMQ_WORKER=default
+RABBITMQ_CONSUME_MODE=poll
+RABBITMQ_EXCHANGE=
+RABBITMQ_EXCHANGE_TYPE=direct
+RABBITMQ_EXCHANGE_ROUTING_KEY=%s
+RABBITMQ_QUEUE_QUORUM=false
+RABBITMQ_QUEUE_LAZY=false
+RABBITMQ_REROUTE_FAILED=false
+```
+
+Pay special attention to:
+
+- `RABBITMQ_CONSUME_MODE=consume`, because it uses push-style `basic_consume` delivery.
+- Quorum queues, because they are not compatible with priority queues.
+- Failed-message rerouting and dead-letter exchange settings.
+- Connection/channel pool limits for long-running workers.
+
+## Worker restart
+
+Always restart queue workers after upgrading package code or config:
+
+```bash
+php artisan queue:restart
+```
+
+Then restart Supervisor, systemd, Horizon, containers, or your process manager so workers load the new code.
+
+## Rollback
+
+If you need to rollback:
+
+1. Stop workers.
+2. Restore the previous package version and config.
+3. Clear config cache.
+4. Restart workers.
+5. Verify no messages are stuck in unacked or dead-letter queues.
+
+```bash
+composer require iamfarhad/laravel-rabbitmq:<previous-version> --with-all-dependencies
+php artisan config:clear
+php artisan queue:restart
+```

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
     "require": {
         "php": "^8.2",
         "ext-amqp": "*",
-        "illuminate/queue": "^11.0|^12.0|^13.0",
-        "illuminate/support": "^11.0|^12.0|^13.0"
+        "illuminate/queue": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0|^10.0|^11.0",
@@ -52,7 +52,9 @@
         "laravel/pint": "^1.10"
     },
     "suggest": {
-        "ext-pcntl": "Required only when running rabbitmq:consume with --num-processes greater than 1."
+        "ext-pcntl": "Required only when running rabbitmq:consume with --num-processes greater than 1.",
+        "laravel/horizon": "Install to enable optional Horizon compatibility via RABBITMQ_WORKER=horizon.",
+        "laravel/octane": "Install to enable optional Octane pool reset compatibility."
     },
     "autoload": {
         "psr-4": {

--- a/docs/comparison-vladimir-yuldashev.md
+++ b/docs/comparison-vladimir-yuldashev.md
@@ -1,0 +1,40 @@
+# Comparison: `iamfarhad/laravel-rabbitmq` vs `vladimir-yuldashev/laravel-queue-rabbitmq`
+
+This page helps teams choose between this package and `vladimir-yuldashev/laravel-queue-rabbitmq`.
+
+## Summary
+
+| Area | `iamfarhad/laravel-rabbitmq` | `vladimir-yuldashev/laravel-queue-rabbitmq` |
+| --- | --- | --- |
+| Primary goal | Production-focused Laravel queue driver with explicit RabbitMQ topology helpers and modern Laravel support | Established Laravel RabbitMQ queue connector with broad community history |
+| AMQP implementation | Native `ext-amqp` | Commonly used with PHP AMQP libraries / package-specific implementation details |
+| Laravel support | 11.x, 12.x, 13.x | Check the upstream package constraints for current support |
+| PHP support | 8.2, 8.3, 8.4, 8.5 | Check the upstream package constraints for current support |
+| RabbitMQ support | 3.13 and 4.x tested in CI; 3.8 - 3.12 best effort | Check upstream docs and CI |
+| Worker modes | Laravel `queue:work`, package `rabbitmq:consume` in `poll` or `consume` mode | Laravel queue worker integration |
+| Connection/channel pooling | Built in | Check upstream implementation |
+| Topology helpers | Exchange/queue declare, purge, delete, pool stats commands | Check upstream feature set |
+| Horizon integration | Optional guarded Horizon event integration | Check upstream feature set |
+| Octane support | Optional pool reset hook | Check upstream feature set |
+| CI matrix | PHP/Laravel matrix plus RabbitMQ 3.13 and 4.x | Check upstream CI |
+
+## When to choose this package
+
+Choose `iamfarhad/laravel-rabbitmq` when you want:
+
+- Native `ext-amqp` support.
+- Explicit support for Laravel 11, 12, and 13.
+- CI coverage for PHP 8.2 through 8.5.
+- CI coverage for RabbitMQ 3.13 and 4.x.
+- Connection and channel pooling.
+- Optional `basic_consume` worker mode for hot queues.
+- Built-in commands for queue/exchange administration.
+- Optional Horizon and Octane integration points.
+
+## Migration notes
+
+See [MIGRATION.md](../MIGRATION.md) for a step-by-step migration guide and configuration mapping.
+
+## Caveats
+
+This comparison is intentionally conservative. Always check the upstream package's latest README, composer constraints, and CI status before making a final decision.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,92 @@
+# Compatibility Guide
+
+## Laravel Horizon
+
+Horizon compatibility is optional and guarded. The package only switches to the Horizon-aware queue class when Horizon is installed and the worker mode is configured as:
+
+```env
+RABBITMQ_WORKER=horizon
+```
+
+When enabled, the queue emits Horizon-compatible pending, pushed, reserved, deleted, and failed job events while keeping normal Laravel queue behavior available when Horizon is not installed.
+
+## Laravel Octane
+
+The package can reuse AMQP pools across long-running Octane workers for performance. To force a fresh pool after every Octane request, enable:
+
+```env
+RABBITMQ_OCTANE_RESET_ON_REQUEST=true
+```
+
+This listener is only registered when Octane classes are available.
+
+## after_commit
+
+The connection supports Laravel's `after_commit` queue behavior through:
+
+```env
+RABBITMQ_AFTER_COMMIT=true
+```
+
+Use this when jobs should only be dispatched after open database transactions commit.
+
+## Lazy connection pools
+
+Lazy connection mode delays creating AMQP connections until the first queue operation. This is useful for CLI commands, Octane workers, and apps that boot the queue connection without always publishing or consuming jobs.
+
+The pool reads the existing host-level `lazy` option and pool-level `lazy` option when present.
+
+## Native network transport
+
+This package uses native `ext-amqp` transport only. Supported transport values are:
+
+- `tcp`
+- `ssl`
+- `tls`
+
+Set the transport in `queue.connections.rabbitmq.transport`, `queue.connections.rabbitmq.protocol`, or per host as `transport` / `protocol`. The legacy `secure=true` option still maps to SSL behavior.
+
+Example:
+
+```php
+'rabbitmq' => [
+    'driver' => 'rabbitmq',
+    'transport' => 'tls',
+    'hosts' => [
+        'host' => env('RABBITMQ_HOST', '127.0.0.1'),
+        'port' => env('RABBITMQ_PORT', 5671),
+        'user' => env('RABBITMQ_USER', 'guest'),
+        'password' => env('RABBITMQ_PASSWORD', 'guest'),
+        'vhost' => env('RABBITMQ_VHOST', '/'),
+    ],
+]
+```
+
+## Raw messages and custom jobs
+
+`RabbitMQJob` is extensible. Set a custom job class in:
+
+```php
+'options' => [
+    'queue' => [
+        'job' => App\Queue\Jobs\CustomRabbitMQJob::class,
+    ],
+],
+```
+
+The custom class must extend `iamfarhad\LaravelRabbitMQ\Jobs\RabbitMQJob`.
+
+The base job exposes helpers for raw RabbitMQ messages:
+
+- `getRawBody()`
+- `headers()`
+- `exchangeName()`
+- `routingKey()`
+- `deliveryTag()`
+- `getRabbitMQMessage()`
+
+Non-JSON messages are converted to a safe payload array containing `raw`, `headers`, and RabbitMQ metadata, so custom job classes can process external producer messages without requiring Laravel's normal serialized job payload.
+
+## No php-amqplib fallback
+
+This package intentionally does not include a `php-amqplib` fallback transport. Native `ext-amqp` remains the only supported AMQP transport.

--- a/src/Connection/ConnectionFactory.php
+++ b/src/Connection/ConnectionFactory.php
@@ -20,19 +20,13 @@ class ConnectionFactory
     {
         $this->config = $config;
         $this->maxRetries = $config['pool']['max_retries'] ?? 3;
-        $this->retryDelay = $config['pool']['retry_delay'] ?? 1000; // milliseconds
+        $this->retryDelay = $config['pool']['retry_delay'] ?? 1000;
     }
 
-    /**
-     * Create a new AMQP connection with retry strategy.
-     *
-     * @throws ConnectionException
-     */
     public function createConnection(): AMQPConnection
     {
         $connectionConfig = $this->buildConnectionConfig();
         $retryDelay = $this->retryDelay;
-
         $attempt = 0;
         $lastException = null;
 
@@ -48,37 +42,45 @@ class ConnectionFactory
 
                 if ($attempt < $this->maxRetries) {
                     usleep($this->retryDelayInMicroseconds($retryDelay));
-                    $retryDelay *= 2; // Exponential backoff for this connection attempt only
+                    $retryDelay *= 2;
                 }
             }
         }
 
         throw new ConnectionException(
-            sprintf(
-                'Failed to connect to RabbitMQ after %d attempts. Last error: %s',
-                $this->maxRetries,
-                $lastException?->getMessage() ?? 'Unknown error'
-            ),
+            sprintf('Failed to connect to RabbitMQ after %d attempts. Last error: %s', $this->maxRetries, $lastException?->getMessage() ?? 'Unknown error'),
             $lastException?->getCode() ?? 0,
             $lastException
         );
     }
 
-    /**
-     * Build connection configuration array.
-     */
+    public function buildConnectionConfigForTesting(): array
+    {
+        return $this->buildConnectionConfig();
+    }
+
     private function buildConnectionConfig(): array
     {
         $hostConfig = $this->selectHostConfig();
         $options = $this->config['options'] ?? [];
+        $transport = $this->resolveTransport($hostConfig);
 
         $config = [
             'host' => $hostConfig['host'] ?? '127.0.0.1',
-            'port' => $hostConfig['port'] ?? 5672,
+            'port' => $hostConfig['port'] ?? ($transport === 'tcp' ? 5672 : 5671),
             'login' => $hostConfig['user'] ?? 'guest',
             'password' => $hostConfig['password'] ?? 'guest',
             'vhost' => $hostConfig['vhost'] ?? '/',
         ];
+
+        if ($transport !== 'tcp') {
+            $config['connection_name'] = $transport;
+            $config['ssl'] = true;
+            $config['cacert'] = $options['ssl_options']['cafile'] ?? null;
+            $config['cert'] = $options['ssl_options']['local_cert'] ?? null;
+            $config['key'] = $options['ssl_options']['local_key'] ?? null;
+            $config['verify'] = $options['ssl_options']['verify_peer'] ?? true;
+        }
 
         $optionalParams = [
             'heartbeat' => 'heartbeat',
@@ -94,12 +96,23 @@ class ConnectionFactory
             }
         }
 
-        return $config;
+        return array_filter($config, static fn ($value) => $value !== null);
     }
 
-    /**
-     * Select a host from either the legacy associative host config or a list of hosts.
-     */
+    private function resolveTransport(array $hostConfig): string
+    {
+        $transport = strtolower((string) ($hostConfig['transport'] ?? $hostConfig['protocol'] ?? $this->config['transport'] ?? $this->config['protocol'] ?? 'tcp'));
+
+        if (($hostConfig['secure'] ?? false) === true && $transport === 'tcp') {
+            return 'ssl';
+        }
+
+        return match ($transport) {
+            'ssl', 'tls' => $transport,
+            default => 'tcp',
+        };
+    }
+
     private function selectHostConfig(): array
     {
         $hosts = $this->config['hosts'] ?? [];
@@ -133,9 +146,6 @@ class ConnectionFactory
         return max(0, (int) round($retryDelay * 1000));
     }
 
-    /**
-     * Test if connection is alive.
-     */
     public function isConnectionAlive(AMQPConnection $connection): bool
     {
         try {
@@ -145,9 +155,6 @@ class ConnectionFactory
         }
     }
 
-    /**
-     * Close connection safely.
-     */
     public function closeConnection(AMQPConnection $connection): void
     {
         try {

--- a/src/Connection/ConnectionPool.php
+++ b/src/Connection/ConnectionPool.php
@@ -28,47 +28,43 @@ class ConnectionPool
 
     private int $lastHealthCheck = 0;
 
+    private bool $lazy;
+
     public function __construct(ConnectionFactory $factory, array $config)
     {
         $this->factory = $factory;
         $this->availableConnections = new SplQueue;
 
         $poolConfig = $config['pool'] ?? [];
+        $hostConfig = $this->firstHostConfig($config['hosts'] ?? []);
         $this->maxConnections = $poolConfig['max_connections'] ?? 10;
         $this->minConnections = $poolConfig['min_connections'] ?? 2;
+        $this->lazy = (bool) ($poolConfig['lazy'] ?? $hostConfig['lazy'] ?? false);
         $this->healthCheckEnabled = $poolConfig['health_check_enabled'] ?? true;
-        $this->healthCheckInterval = $poolConfig['health_check_interval'] ?? 30; // seconds
+        $this->healthCheckInterval = $poolConfig['health_check_interval'] ?? 30;
 
-        // Initialize minimum connections
-        $this->initializePool();
+        if (! $this->lazy) {
+            $this->initializePool();
+        }
     }
 
-    /**
-     * Get a connection from the pool
-     *
-     * @throws ConnectionException
-     */
     public function getConnection(): AMQPConnection
     {
         $this->performHealthCheckIfNeeded();
 
-        // Try to get an available connection
         if (! $this->availableConnections->isEmpty()) {
             $connection = $this->availableConnections->dequeue();
 
-            // Verify connection is still alive
             if ($this->factory->isConnectionAlive($connection)) {
                 $connectionId = spl_object_id($connection);
                 $this->activeConnections[$connectionId] = $connection;
 
                 return $connection;
             }
-            // Connection is dead, remove it and create a new one
-            $this->currentConnections--;
 
+            $this->currentConnections--;
         }
 
-        // Create new connection if under limit
         if ($this->currentConnections < $this->maxConnections) {
             $connection = $this->createNewConnection();
             $connectionId = spl_object_id($connection);
@@ -77,17 +73,9 @@ class ConnectionPool
             return $connection;
         }
 
-        throw new ConnectionException(
-            sprintf(
-                'Connection pool exhausted. Maximum connections (%d) reached.',
-                $this->maxConnections
-            )
-        );
+        throw new ConnectionException(sprintf('Connection pool exhausted. Maximum connections (%d) reached.', $this->maxConnections));
     }
 
-    /**
-     * Return a connection to the pool
-     */
     public function releaseConnection(AMQPConnection $connection): void
     {
         $connectionId = spl_object_id($connection);
@@ -98,28 +86,21 @@ class ConnectionPool
 
         unset($this->activeConnections[$connectionId]);
 
-        // Check if connection is still alive before returning to pool
         if ($this->factory->isConnectionAlive($connection)) {
             $this->availableConnections->enqueue($connection);
         } else {
-            // Connection is dead, don't return to pool
             $this->currentConnections--;
         }
     }
 
-    /**
-     * Close a specific connection and remove from pool
-     */
     public function closeConnection(AMQPConnection $connection): void
     {
         $connectionId = spl_object_id($connection);
 
-        // Remove from active connections
         if (isset($this->activeConnections[$connectionId])) {
             unset($this->activeConnections[$connectionId]);
         }
 
-        // Remove from available connections if present
         $tempQueue = new SplQueue;
         while (! $this->availableConnections->isEmpty()) {
             $conn = $this->availableConnections->dequeue();
@@ -133,19 +114,13 @@ class ConnectionPool
         $this->currentConnections--;
     }
 
-    /**
-     * Close all connections and clean up the pool
-     */
     public function closeAll(): void
     {
-
-        // Close active connections
         foreach ($this->activeConnections as $connection) {
             $this->factory->closeConnection($connection);
         }
         $this->activeConnections = [];
 
-        // Close available connections
         while (! $this->availableConnections->isEmpty()) {
             $connection = $this->availableConnections->dequeue();
             $this->factory->closeConnection($connection);
@@ -154,9 +129,6 @@ class ConnectionPool
         $this->currentConnections = 0;
     }
 
-    /**
-     * Get pool statistics
-     */
     public function getStats(): array
     {
         return [
@@ -165,14 +137,12 @@ class ConnectionPool
             'current_connections' => $this->currentConnections,
             'active_connections' => count($this->activeConnections),
             'available_connections' => $this->availableConnections->count(),
+            'lazy' => $this->lazy,
             'health_check_enabled' => $this->healthCheckEnabled,
             'last_health_check' => $this->lastHealthCheck,
         ];
     }
 
-    /**
-     * Initialize the pool with minimum connections
-     */
     private function initializePool(): void
     {
         for ($i = 0; $i < $this->minConnections; $i++) {
@@ -185,9 +155,6 @@ class ConnectionPool
         }
     }
 
-    /**
-     * Create a new connection and increment counter
-     */
     private function createNewConnection(): AMQPConnection
     {
         $connection = $this->factory->createConnection();
@@ -196,9 +163,6 @@ class ConnectionPool
         return $connection;
     }
 
-    /**
-     * Perform health check on available connections if needed
-     */
     private function performHealthCheckIfNeeded(): void
     {
         if (! $this->healthCheckEnabled) {
@@ -214,13 +178,9 @@ class ConnectionPool
         $this->performHealthCheck();
     }
 
-    /**
-     * Check health of all available connections
-     */
     private function performHealthCheck(): void
     {
         $healthyConnections = new SplQueue;
-        $removedCount = 0;
 
         while (! $this->availableConnections->isEmpty()) {
             $connection = $this->availableConnections->dequeue();
@@ -230,13 +190,22 @@ class ConnectionPool
             } else {
                 $this->factory->closeConnection($connection);
                 $this->currentConnections--;
-                $removedCount++;
             }
         }
 
         $this->availableConnections = $healthyConnections;
+    }
 
-        if ($removedCount > 0) {
+    private function firstHostConfig(array $hosts): array
+    {
+        if ($hosts === []) {
+            return [];
         }
+
+        if (array_is_list($hosts) && isset($hosts[0]) && is_array($hosts[0])) {
+            return $hosts[0];
+        }
+
+        return $hosts;
     }
 }

--- a/src/Jobs/RabbitMQJob.php
+++ b/src/Jobs/RabbitMQJob.php
@@ -13,11 +13,11 @@ use Illuminate\Support\Arr;
 use JsonException;
 use Throwable;
 
-final class RabbitMQJob extends Job implements JobContract
+class RabbitMQJob extends Job implements JobContract
 {
     private const FAILED_MESSAGES_EXCHANGE = 'failed_messages';
 
-    private readonly array $decoded;
+    protected array $decoded = [];
 
     public function __construct(
         Container $container,
@@ -32,25 +32,61 @@ final class RabbitMQJob extends Job implements JobContract
         $this->decoded = $this->payload();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getJobId(): ?string
     {
-        return $this->decoded['id'] ?? null;
+        return $this->decoded['id'] ?? $this->amqpEnvelope->getCorrelationId() ?: null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRawBody(): string
     {
         return $this->amqpEnvelope->getBody();
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    public function headers(): array
+    {
+        return (array) ($this->amqpEnvelope->getHeaders() ?: []);
+    }
+
+    public function exchangeName(): ?string
+    {
+        $exchange = $this->amqpEnvelope->getExchangeName();
+
+        return $exchange !== '' ? $exchange : null;
+    }
+
+    public function routingKey(): ?string
+    {
+        if (! method_exists($this->amqpEnvelope, 'getRoutingKey')) {
+            return null;
+        }
+
+        $routingKey = $this->amqpEnvelope->getRoutingKey();
+
+        return $routingKey !== '' ? $routingKey : null;
+    }
+
+    public function deliveryTag(): ?string
+    {
+        $deliveryTag = $this->amqpEnvelope->getDeliveryTag();
+
+        return $deliveryTag !== null ? (string) $deliveryTag : null;
+    }
+
+    private function convertMessageToFailed(): void
+    {
+        try {
+            if ($this->amqpEnvelope->getExchangeName() !== self::FAILED_MESSAGES_EXCHANGE) {
+                if (! $this->rabbitQueue->getConnection()->isConnected()) {
+                    return;
+                }
+
+                $this->rabbitQueue->declareQueue(self::FAILED_MESSAGES_EXCHANGE);
+                $this->rabbitQueue->pushRaw($this->amqpEnvelope->getBody(), self::FAILED_MESSAGES_EXCHANGE);
+            }
+        } catch (Throwable) {
+        }
+    }
+
     public function attempts(): int
     {
         if (! $rabbitMQMessageHeaders = $this->getRabbitMQMessageHeaders()) {
@@ -62,76 +98,26 @@ final class RabbitMQJob extends Job implements JobContract
         return $laravelAttempts + 1;
     }
 
-    /**
-     * @throws JsonException
-     */
-    private function convertMessageToFailed(): void
-    {
-        try {
-            if ($this->amqpEnvelope->getExchangeName() !== self::FAILED_MESSAGES_EXCHANGE) {
-                // Check if the RabbitMQ connection is still available before attempting operations
-                if (! $this->rabbitQueue->getConnection()->isConnected()) {
-
-                    return;
-                }
-
-                $this->rabbitQueue->declareQueue(self::FAILED_MESSAGES_EXCHANGE);
-                $this->rabbitQueue->pushRaw($this->amqpEnvelope->getBody(), self::FAILED_MESSAGES_EXCHANGE);
-            }
-        } catch (Throwable $e) {
-            // If channel is not available or queue declaration fails, just log the error
-            // This can happen when the connection is lost during job processing
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws JsonException
-     */
     public function markAsFailed(): void
     {
         parent::markAsFailed();
-
-        // We must tell rabbitMQ this Job is failed
-        // The message must be rejected when the Job marked as failed, in case rabbitMQ wants to do some extra magic.
-        // like: Death lettering the message to another exchange/routing-key.
         $this->rabbitQueue->reject($this);
-
         $this->convertMessageToFailed();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function delete(): void
     {
         parent::delete();
 
-        // When delete is called and the Job was not failed, the message must be acknowledged.
-        // This is because this is a controlled call by a developer. So the message was handled correct.
         if (! $this->failed) {
             $this->rabbitQueue->ack($this);
         }
     }
 
-    /**
-     * Release the job back into the queue.
-     *
-     * @param  int  $delay
-     *
-     * @throws JsonException
-     */
     public function release($delay = 0): void
     {
         parent::release();
-
-        // Always create a new message when this Job is released
         $this->rabbitQueue->laterRaw($delay, $this->amqpEnvelope->getBody(), $this->queue, $this->attempts());
-
-        // Releasing a Job means the message was failed to process.
-        // Because this Job message is always recreated and pushed as new message, this Job message is correctly handled.
-        // We must tell rabbitMQ this job message can be removed by acknowledging the message.
         $this->rabbitQueue->ack($this);
     }
 
@@ -145,11 +131,11 @@ final class RabbitMQJob extends Job implements JobContract
         return $this->amqpEnvelope;
     }
 
-    private function getRabbitMQMessageHeaders(): ?array
+    protected function getRabbitMQMessageHeaders(): ?array
     {
-        $headers = $this->amqpEnvelope->getHeaders();
+        $headers = $this->headers();
 
-        if (! $headers || ! isset($headers['laravel'])) {
+        if ($headers === [] || ! isset($headers['laravel'])) {
             return null;
         }
 

--- a/src/Jobs/RabbitMQJob.php
+++ b/src/Jobs/RabbitMQJob.php
@@ -10,6 +10,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job as JobContract;
 use Illuminate\Queue\Jobs\Job;
 use Illuminate\Support\Arr;
+use JsonException;
 use Throwable;
 
 class RabbitMQJob extends Job implements JobContract
@@ -29,6 +30,33 @@ class RabbitMQJob extends Job implements JobContract
         $this->connectionName = $connectionName;
         $this->queue = $queue;
         $this->decoded = $this->payload();
+    }
+
+    public function payload(): array
+    {
+        try {
+            $payload = json_decode($this->getRawBody(), true, 512, JSON_THROW_ON_ERROR);
+
+            if (is_array($payload)) {
+                return $payload;
+            }
+        } catch (JsonException) {
+        }
+
+        return [
+            'id' => $this->amqpEnvelope->getCorrelationId() ?: null,
+            'raw' => $this->getRawBody(),
+            'headers' => $this->headers(),
+            'displayName' => static::class,
+            'job' => static::class,
+            'maxTries' => null,
+            'maxExceptions' => null,
+            'failOnTimeout' => false,
+            'backoff' => null,
+            'timeout' => null,
+            'retryUntil' => null,
+            'data' => [],
+        ];
     }
 
     public function getJobId(): ?string

--- a/src/Jobs/RabbitMQJob.php
+++ b/src/Jobs/RabbitMQJob.php
@@ -10,7 +10,6 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job as JobContract;
 use Illuminate\Queue\Jobs\Job;
 use Illuminate\Support\Arr;
-use JsonException;
 use Throwable;
 
 class RabbitMQJob extends Job implements JobContract

--- a/tests/Feature/RabbitMQQueueTest.php
+++ b/tests/Feature/RabbitMQQueueTest.php
@@ -45,7 +45,7 @@ class RabbitMQQueueTest extends TestCase
     public function testCanPushDelayedJob(): void
     {
         $job = new TestJob('delayed-payload');
-        $delay = 60; // 60 seconds
+        $delay = 60;
 
         $jobId = Queue::later($delay, $job);
 
@@ -57,10 +57,8 @@ class RabbitMQQueueTest extends TestCase
     {
         $queueName = 'size-test-queue';
 
-        // Push a job to the queue
         Queue::pushOn($queueName, new TestJob('size-test'));
 
-        // Get queue size
         $size = Queue::size($queueName);
 
         $this->assertIsInt($size);
@@ -72,7 +70,6 @@ class RabbitMQQueueTest extends TestCase
         $jobs = [
             new TestJob('bulk-job-1'),
             new TestJob('bulk-job-2'),
-
             new TestJob('bulk-job-3'),
         ];
 
@@ -86,15 +83,13 @@ class RabbitMQQueueTest extends TestCase
     {
         $connection = Queue::connection('rabbitmq');
 
-        // Test that the connection uses the correct configuration
         $this->assertEquals('rabbitmq', $connection->getConnectionName());
     }
 
     public function testCanHandleJobFailuresGracefully(): void
     {
-        $job = new TestJob('failing-job', false); // Job that won't fail during push
+        $job = new TestJob('failing-job', false);
 
-        // This should not throw an exception when pushing
         $jobId = Queue::push($job);
         $this->assertNotNull($jobId);
     }
@@ -103,14 +98,12 @@ class RabbitMQQueueTest extends TestCase
     {
         $queueName = 'purge-test-queue';
 
-        // Push some jobs
         Queue::pushOn($queueName, new TestJob('purge-test-1'));
         Queue::pushOn($queueName, new TestJob('purge-test-2'));
 
         $connection = Queue::connection('rabbitmq');
         $result = $connection->purgeQueue($queueName);
 
-        // Purge should succeed (returns number of purged messages or null)
         $this->assertTrue($result >= 0 || $result === null);
     }
 
@@ -118,13 +111,11 @@ class RabbitMQQueueTest extends TestCase
     {
         $queueName = 'delete-test-queue';
 
-        // Create queue by pushing a job
         Queue::pushOn($queueName, new TestJob('delete-test'));
 
         $connection = Queue::connection('rabbitmq');
         $result = $connection->deleteQueue($queueName);
 
-        // Delete should succeed
         $this->assertTrue($result >= 0 || $result === null);
     }
 
@@ -133,24 +124,18 @@ class RabbitMQQueueTest extends TestCase
         $queueName = 'existence-test-queue';
         $connection = Queue::connection('rabbitmq');
 
-        // Clean up first in case queue exists
         try {
             $connection->deleteQueue($queueName);
-        } catch (Exception $e) {
-            // Ignore if queue doesn't exist
+        } catch (Exception) {
         }
 
-        // Create queue by pushing a job first (this should work)
         Queue::pushOn($queueName, new TestJob('existence-test'));
 
-        // Now queue should exist
         $this->assertTrue($connection->queueExists($queueName));
 
-        // Clean up the job and verify queue is empty but still exists
         $connection->purgeQueue($queueName);
         $this->assertTrue($connection->queueExists($queueName));
 
-        // Finally delete the queue
         $connection->deleteQueue($queueName);
     }
 
@@ -159,7 +144,6 @@ class RabbitMQQueueTest extends TestCase
         $queueName = 'pop-test-queue';
         $testPayload = 'pop-test-payload';
 
-        // Push a job
         Queue::pushOn($queueName, new TestJob($testPayload));
 
         $connection = Queue::connection('rabbitmq');
@@ -169,33 +153,44 @@ class RabbitMQQueueTest extends TestCase
         $this->assertInstanceOf(RabbitMQJob::class, $job);
     }
 
+    public function testCanPopRawNonJsonPayloadFromQueue(): void
+    {
+        $queueName = 'raw-payload-test-queue';
+        $rawPayload = 'plain-text-message';
+
+        $connection = Queue::connection('rabbitmq');
+        $connection->pushRaw($rawPayload, $queueName);
+
+        $job = $connection->pop($queueName);
+
+        $this->assertNotNull($job);
+        $this->assertInstanceOf(RabbitMQJob::class, $job);
+        $this->assertSame($rawPayload, $job->getRawBody());
+        $this->assertSame($rawPayload, $job->payload()['raw']);
+        $this->assertIsArray($job->headers());
+    }
+
     public function testReturnsNullForEmptyQueue(): void
     {
         $queueName = 'empty-test-queue';
         $connection = Queue::connection('rabbitmq');
 
-        // First create the queue by pushing a job
         Queue::pushOn($queueName, new TestJob('test'));
 
-        // Then consume the job to empty the queue
         $job = $connection->pop($queueName);
         $this->assertNotNull($job);
 
-        // Now try to pop from the empty queue - should return null
         $job = $connection->pop($queueName);
         $this->assertNull($job);
 
-        // Clean up
         try {
             $connection->deleteQueue($queueName);
-        } catch (Exception $e) {
-            // Ignore cleanup errors
+        } catch (Exception) {
         }
     }
 
     public function testHandlesConnectionErrorsGracefully(): void
     {
-        // Test with invalid configuration
         config(['queue.connections.rabbitmq.hosts.host' => 'invalid-host']);
 
         $this->expectException(Exception::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,8 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
 {
+    protected static $latestResponse;
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Unit/ConnectionFactoryTest.php
+++ b/tests/Unit/ConnectionFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use iamfarhad\LaravelRabbitMQ\Connection\ConnectionFactory;
+use iamfarhad\LaravelRabbitMQ\Tests\UnitTestCase;
+
+class ConnectionFactoryTest extends UnitTestCase
+{
+    public function testBuildsDefaultTcpConnectionConfig(): void
+    {
+        $factory = new ConnectionFactory([
+            'hosts' => [
+                'host' => 'rabbitmq.local',
+                'user' => 'laravel',
+                'password' => 'secret',
+                'vhost' => 'app',
+            ],
+        ]);
+
+        $config = $factory->buildConnectionConfigForTesting();
+
+        $this->assertSame('rabbitmq.local', $config['host']);
+        $this->assertSame(5672, $config['port']);
+        $this->assertSame('laravel', $config['login']);
+        $this->assertSame('secret', $config['password']);
+        $this->assertSame('app', $config['vhost']);
+        $this->assertArrayNotHasKey('ssl', $config);
+    }
+
+    public function testSecureHostMapsToSslTransport(): void
+    {
+        $factory = new ConnectionFactory([
+            'hosts' => [
+                'host' => 'rabbitmq.local',
+                'secure' => true,
+            ],
+        ]);
+
+        $config = $factory->buildConnectionConfigForTesting();
+
+        $this->assertSame(5671, $config['port']);
+        $this->assertTrue($config['ssl']);
+        $this->assertSame('ssl', $config['connection_name']);
+    }
+}

--- a/tests/Unit/ConnectionPoolTest.php
+++ b/tests/Unit/ConnectionPoolTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use AMQPConnection;
+use iamfarhad\LaravelRabbitMQ\Connection\ConnectionFactory;
+use iamfarhad\LaravelRabbitMQ\Connection\ConnectionPool;
+use iamfarhad\LaravelRabbitMQ\Tests\UnitTestCase;
+use Mockery;
+
+class ConnectionPoolTest extends UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skipIfAmqpExtensionLoaded();
+    }
+
+    public function testLazyPoolDoesNotCreateMinimumConnectionsOnConstruction(): void
+    {
+        $factory = Mockery::mock(ConnectionFactory::class);
+        $factory->shouldNotReceive('createConnection');
+
+        $pool = new ConnectionPool($factory, [
+            'hosts' => [
+                'lazy' => true,
+            ],
+            'pool' => [
+                'min_connections' => 2,
+                'max_connections' => 5,
+                'lazy' => true,
+                'health_check_enabled' => false,
+            ],
+        ]);
+
+        $stats = $pool->getStats();
+
+        $this->assertTrue($stats['lazy']);
+        $this->assertSame(0, $stats['current_connections']);
+        $this->assertSame(0, $stats['available_connections']);
+    }
+
+    public function testNonLazyPoolCreatesMinimumConnectionsOnConstruction(): void
+    {
+        $connection = Mockery::mock(AMQPConnection::class);
+        $factory = Mockery::mock(ConnectionFactory::class);
+        $factory->shouldReceive('createConnection')->twice()->andReturn($connection);
+
+        $pool = new ConnectionPool($factory, [
+            'hosts' => [
+                'lazy' => false,
+            ],
+            'pool' => [
+                'min_connections' => 2,
+                'max_connections' => 5,
+                'lazy' => false,
+                'health_check_enabled' => false,
+            ],
+        ]);
+
+        $stats = $pool->getStats();
+
+        $this->assertFalse($stats['lazy']);
+        $this->assertSame(2, $stats['current_connections']);
+        $this->assertSame(2, $stats['available_connections']);
+    }
+}

--- a/tests/Unit/RabbitMQJobTest.php
+++ b/tests/Unit/RabbitMQJobTest.php
@@ -72,6 +72,4 @@ class RabbitMQJobTest extends UnitTestCase
     }
 }
 
-class CustomRabbitMQJobForTest extends RabbitMQJob
-{
-}
+class CustomRabbitMQJobForTest extends RabbitMQJob {}

--- a/tests/Unit/RabbitMQJobTest.php
+++ b/tests/Unit/RabbitMQJobTest.php
@@ -2,15 +2,10 @@
 
 declare(strict_types=1);
 
-// Test only basic job structure without AMQP connections
-// Connection-dependent tests are covered in Feature tests
-
 use iamfarhad\LaravelRabbitMQ\Jobs\RabbitMQJob;
 use iamfarhad\LaravelRabbitMQ\Tests\UnitTestCase;
 use Illuminate\Queue\Jobs\Job;
 
-// RabbitMQJob tests require real AMQPEnvelope objects which need connections
-// All job functionality is thoroughly tested in Feature tests with real RabbitMQ
 class RabbitMQJobTest extends UnitTestCase
 {
     public function testValidatesJobClassExists(): void
@@ -22,7 +17,6 @@ class RabbitMQJobTest extends UnitTestCase
     {
         $reflection = new ReflectionClass(RabbitMQJob::class);
 
-        // Check that it extends the correct base class
         $this->assertTrue($reflection->isSubclassOf(Job::class));
     }
 
@@ -30,34 +24,54 @@ class RabbitMQJobTest extends UnitTestCase
     {
         $reflection = new ReflectionClass(RabbitMQJob::class);
 
-        // Check for required methods
         $this->assertTrue($reflection->hasMethod('getRawBody'));
         $this->assertTrue($reflection->hasMethod('delete'));
         $this->assertTrue($reflection->hasMethod('release'));
         $this->assertTrue($reflection->hasMethod('attempts'));
         $this->assertTrue($reflection->hasMethod('getJobId'));
+        $this->assertTrue($reflection->hasMethod('headers'));
+        $this->assertTrue($reflection->hasMethod('exchangeName'));
+        $this->assertTrue($reflection->hasMethod('routingKey'));
+        $this->assertTrue($reflection->hasMethod('deliveryTag'));
     }
 
     public function testJobClassMethodsArePublic(): void
     {
         $reflection = new ReflectionClass(RabbitMQJob::class);
 
-        $methods = ['getRawBody', 'delete', 'release', 'attempts', 'getJobId'];
+        $methods = [
+            'getRawBody',
+            'delete',
+            'release',
+            'attempts',
+            'getJobId',
+            'headers',
+            'exchangeName',
+            'routingKey',
+            'deliveryTag',
+        ];
 
         foreach ($methods as $methodName) {
-            if ($reflection->hasMethod($methodName)) {
-                $method = $reflection->getMethod($methodName);
-                $this->assertTrue($method->isPublic(), "Method {$methodName} should be public");
-            }
+            $method = $reflection->getMethod($methodName);
+            $this->assertTrue($method->isPublic(), "Method {$methodName} should be public");
         }
     }
 
-    public function testJobClassIsInstantiable(): void
+    public function testJobClassIsInstantiableAndExtensible(): void
     {
         $reflection = new ReflectionClass(RabbitMQJob::class);
 
-        // The class should be instantiable (not abstract)
         $this->assertFalse($reflection->isAbstract());
+        $this->assertFalse($reflection->isFinal());
         $this->assertTrue($reflection->isInstantiable());
     }
+
+    public function testConfiguredCustomJobClassCanExtendRabbitMQJob(): void
+    {
+        $this->assertTrue(is_a(CustomRabbitMQJobForTest::class, RabbitMQJob::class, true));
+    }
+}
+
+class CustomRabbitMQJobForTest extends RabbitMQJob
+{
 }

--- a/tests/Unit/RabbitMQJobTest.php
+++ b/tests/Unit/RabbitMQJobTest.php
@@ -72,4 +72,6 @@ class RabbitMQJobTest extends UnitTestCase
     }
 }
 
-class CustomRabbitMQJobForTest extends RabbitMQJob {}
+class CustomRabbitMQJobForTest extends RabbitMQJob
+{
+}


### PR DESCRIPTION
## Summary

This PR implements the repository maintenance and compatibility checklist:

- Add `SUPPORT.md` with Laravel/PHP/RabbitMQ support matrices.
- Add `SECURITY.md` with private vulnerability reporting guidance.
- Add bug report and feature request issue templates.
- Add pull request template.
- Add `CONTRIBUTING.md`.
- Add `UPGRADE.md`.
- Add `MIGRATION.md`.
- Add comparison page vs `vladimir-yuldashev/laravel-queue-rabbitmq`.
- Add `docs/compatibility.md` for Horizon, Octane, after_commit, lazy pools, native transport, raw messages, and custom job support.
- Expand CI to include Composer `prefer-lowest` / `prefer-stable` jobs.
- Add PHP 8.5 to the test matrix.
- Add Laravel 10 support in composer constraints and CI matrix.
- Add RabbitMQ 3.13 and 4.x matrix coverage.
- Fix README rendering/wording issues and link to the new docs.

## Compatibility implementation

- Horizon compatibility remains optional and guarded by installed Horizon classes plus `RABBITMQ_WORKER=horizon`.
- Octane compatibility keeps AMQP pools reusable by default and supports request-end pool cleanup through `RABBITMQ_OCTANE_RESET_ON_REQUEST=true`.
- `after_commit` is already passed through to Laravel Queue and documented.
- Lazy connection pools now honor the existing lazy option and avoid eager pool initialization.
- Native `ext-amqp` transport now accepts `tcp`, `ssl`, and `tls` style configuration.
- `RabbitMQJob` is no longer final, supports custom subclasses, exposes RabbitMQ metadata helpers, and safely wraps non-JSON/raw payloads.

## Explicitly not included

- No `php-amqplib` fallback transport was added. Native `ext-amqp` remains the only supported AMQP transport.

## Testing

Not run locally. Validation is expected through the PR workflow.